### PR TITLE
Add block append command

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Usage:
   hcledit block [command]
 
 Available Commands:
+  append      Append block
   get         Get block
   list        List block
   mv          Move block (Rename block type and labels)
@@ -179,6 +180,20 @@ resource "foo" "baz" {
 $ cat tmp/block.hcl | hcledit block rm resource.foo.baz
 resource "foo" "bar" {
   attr1 = "val1"
+}
+```
+
+```
+$ cat tmp/block.hcl | go run main.go block append resource.foo.bar block1.label1 --newline
+resource "foo" "bar" {
+  attr1 = "val1"
+
+  block1 "label1" {
+  }
+}
+
+resource "foo" "baz" {
+  attr1 = "val2"
 }
 ```
 

--- a/cmd/block.go
+++ b/cmd/block.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/minamijoyo/hcledit/editor"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func init() {
@@ -25,6 +26,7 @@ func newBlockCmd() *cobra.Command {
 		newBlockMvCmd(),
 		newBlockListCmd(),
 		newBlockRmCmd(),
+		newBlockAppendCmd(),
 	)
 
 	return cmd
@@ -123,4 +125,36 @@ func runBlockRmCmd(cmd *cobra.Command, args []string) error {
 	address := args[0]
 
 	return editor.RemoveBlock(cmd.InOrStdin(), cmd.OutOrStdout(), "-", address)
+}
+
+func newBlockAppendCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "append <PARENT_ADDRESS> <CHILD_ADDRESS>",
+		Short: "Append block",
+		Long: `Append a new child block to matched blocks at a given parent block address
+
+Arguments:
+  PARENT_ADDRESS      A parent block address to be appended.
+  CHILD_ADDRESS       A new child block relative address.
+`,
+		RunE: runBlockAppendCmd,
+	}
+
+	flags := cmd.Flags()
+	flags.Bool("newline", false, "Append a new line before a new child block")
+	viper.BindPFlag("block.append.newline", flags.Lookup("newline"))
+
+	return cmd
+}
+
+func runBlockAppendCmd(cmd *cobra.Command, args []string) error {
+	if len(args) != 2 {
+		return fmt.Errorf("expected 2 argument, but got %d arguments", len(args))
+	}
+
+	parent := args[0]
+	child := args[1]
+	newline := viper.GetBool("block.append.newline")
+
+	return editor.AppendBlock(cmd.InOrStdin(), cmd.OutOrStdout(), "-", parent, child, newline)
 }

--- a/cmd/mock.go
+++ b/cmd/mock.go
@@ -24,6 +24,18 @@ func newMockCmd(runE func(cmd *cobra.Command, args []string) error, input string
 	return cmd
 }
 
+func newMockCmdWithFlag(cmd *cobra.Command, input string) *cobra.Command {
+	inStream := bytes.NewBufferString(input)
+	outStream := new(bytes.Buffer)
+	errStream := new(bytes.Buffer)
+
+	cmd.SetIn(inStream)
+	cmd.SetOut(outStream)
+	cmd.SetErr(errStream)
+
+	return cmd
+}
+
 // mockErr is a helper function which returns a string written to mocked err stream.
 func mockErr(cmd *cobra.Command) string {
 	return cmd.ErrOrStderr().(*bytes.Buffer).String()

--- a/editor/block_append.go
+++ b/editor/block_append.go
@@ -1,0 +1,62 @@
+package editor
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// AppendBlock reads HCL from io.Reader, and appends a new child block to
+// matched blocks at a given parent block address, and writes the updated HCL
+// to io.Writer.
+// The child address is relative to parent one.
+// If a newline flag is true, it also appends a newline before the new block.
+// Note that a filename is used only for an error message.
+// If an error occurs, Nothing is written to the output stream.
+func AppendBlock(r io.Reader, w io.Writer, filename string, parent string, child string, newline bool) error {
+	e := &Editor{
+		source: &parser{filename: filename},
+		filters: []Filter{
+			&blockAppend{
+				parent:  parent,
+				child:   child,
+				newline: newline,
+			},
+		},
+		sink: &formater{},
+	}
+
+	return e.Apply(r, w)
+}
+
+// blockAppend is a filter implementation for block.
+type blockAppend struct {
+	parent  string
+	child   string
+	newline bool
+}
+
+// Filter reads HCL and appends only matched blocks at a given address.
+func (f *blockAppend) Filter(inFile *hclwrite.File) (*hclwrite.File, error) {
+	pTypeName, pLabels, err := parseAddress(f.parent)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse parent address: %s", err)
+	}
+
+	cTypeName, cLabels, err := parseAddress(f.child)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse child address: %s", err)
+	}
+
+	matched := findBlocks(inFile.Body(), pTypeName, pLabels)
+
+	for _, b := range matched {
+		if f.newline {
+			b.Body().AppendNewline()
+		}
+		b.Body().AppendNewBlock(cTypeName, cLabels)
+	}
+
+	return inFile, nil
+}

--- a/editor/block_append_test.go
+++ b/editor/block_append_test.go
@@ -1,0 +1,177 @@
+package editor
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestBlockAppend(t *testing.T) {
+	cases := []struct {
+		name    string
+		src     string
+		parent  string
+		child   string
+		newline bool
+		ok      bool
+		want    string
+	}{
+		{
+			name: "simple",
+			src: `
+a0 = v0
+b1 {
+  a2 = v2
+}
+
+b2 l1 {
+}
+`,
+			parent:  "b1",
+			child:   "b11",
+			newline: false,
+			ok:      true,
+			want: `
+a0 = v0
+b1 {
+  a2 = v2
+  b11 {
+  }
+}
+
+b2 l1 {
+}
+`,
+		},
+		{
+			name: "no match",
+			src: `
+a0 = v0
+b1 {
+  a2 = v2
+}
+
+b2 l1 {
+}
+`,
+			parent:  "not_found",
+			child:   "b11",
+			newline: false,
+			ok:      true,
+			want: `
+a0 = v0
+b1 {
+  a2 = v2
+}
+
+b2 l1 {
+}
+`,
+		},
+		{
+			name:    "empty",
+			parent:  "",
+			child:   "b11",
+			newline: false,
+			ok:      false,
+			want:    "",
+		},
+		{
+			name: "with label",
+			src: `
+a0 = v0
+b1 {
+  a2 = v2
+}
+
+b1 l1 {
+}
+`,
+			parent:  "b1.l1",
+			child:   "b11.l11.l12",
+			newline: false,
+			ok:      true,
+			want: `
+a0 = v0
+b1 {
+  a2 = v2
+}
+
+b1 l1 {
+  b11 "l11" "l12" {
+  }
+}
+`,
+		},
+		{
+			name: "multi blocks",
+			src: `
+b1 {
+}
+
+b1 l1 {
+}
+
+b1 l1 {
+}
+`,
+			parent:  "b1.l1",
+			child:   "b11.l11.l12",
+			newline: false,
+			ok:      true,
+			want: `
+b1 {
+}
+
+b1 l1 {
+  b11 "l11" "l12" {
+  }
+}
+
+b1 l1 {
+  b11 "l11" "l12" {
+  }
+}
+`,
+		},
+		{
+			name: "append newline",
+			src: `
+b1 {
+  a1 = v1
+}
+`,
+			parent:  "b1",
+			child:   "b11",
+			newline: true,
+			ok:      true,
+			want: `
+b1 {
+  a1 = v1
+
+  b11 {
+  }
+}
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inStream := bytes.NewBufferString(tc.src)
+			outStream := new(bytes.Buffer)
+			err := AppendBlock(inStream, outStream, "test", tc.parent, tc.child, tc.newline)
+			if tc.ok && err != nil {
+				t.Fatalf("unexpected err = %s", err)
+			}
+
+			got := outStream.String()
+			if !tc.ok && err == nil {
+				t.Fatalf("expected to return an error, but no error, outStream: \n%s", got)
+			}
+
+			if got != tc.want {
+				t.Fatalf("got:\n%s\nwant:\n%s", got, tc.want)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/hashicorp/logutils v1.0.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.4.0 // indirect
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,7 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3vkb4ax0b5D2DHbNAUsen0Gx5wZoq3lV4=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
+github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -51,6 +52,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
@@ -62,6 +64,7 @@ github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/viper v1.3.2 h1:VUFqw5KcqRf7i70GOzW7N+Q7+gxVBkSSqiXB12+JQ4M=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=


### PR DESCRIPTION
Allow us to append a new child block to matched blocks at a given parent block address.
The child address is relative to parent one.

```
$ go run main.go block append --help
Append a new child block to matched blocks at a given parent block address

Arguments:
  PARENT_ADDRESS      A parent block address to be appended.
  CHILD_ADDRESS       A new child block relative address.

Usage:
  hcledit block append <PARENT_ADDRESS> <CHILD_ADDRESS> [flags]

Flags:
  -h, --help      help for append
      --newline   Append a new line before a new child block
```

```
$ cat tmp/block.hcl
resource "foo" "bar" {
  attr1 = "val1"
}

resource "foo" "baz" {
  attr1 = "val2"
}
```

```
$ cat tmp/block.hcl | go run main.go block append resource.foo.bar block1.label1 --newline
resource "foo" "bar" {
  attr1 = "val1"

  block1 "label1" {
  }
}

resource "foo" "baz" {
  attr1 = "val2"
}
```

We may want to insert it in the middle of body of the block instead of at the end, in that case, we should implement it as a separate command if necessary, because it will probably have different address format.

If a newline flag is true, it also appends a newline before the new block.  Because the official hcl formatter doesn't have any opinion about vertical whitespace, whether or not to add it is user's preference.

In testing, the current mock implementation of newMockCmd doesn't support parsing optional flags. It will require some refactorings to support it. So, I temporary added newMockCmdWithFlag, but it should merge to newMockCmd.