### PR TITLE
Refactor to test argument flags

### DIFF
--- a/cmd/attribute_test.go
+++ b/cmd/attribute_test.go
@@ -48,22 +48,8 @@ func TestAttributeGet(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := newMockCmd(runAttributeGetCmd, src)
-
-			err := runAttributeGetCmd(cmd, tc.args)
-			stderr := mockErr(cmd)
-			if tc.ok && err != nil {
-				t.Fatalf("unexpected err = %s, stderr: \n%s", err, stderr)
-			}
-
-			stdout := mockOut(cmd)
-			if !tc.ok && err == nil {
-				t.Fatalf("expected to return an error, but no error, stdout: \n%s", stdout)
-			}
-
-			if stdout != tc.want {
-				t.Fatalf("got:\n%s\nwant:\n%s", stdout, tc.want)
-			}
+			cmd := newMockCmd(newAttributeGetCmd(), src)
+			assertMockCmd(t, cmd, tc.args, tc.ok, tc.want)
 		})
 	}
 }
@@ -150,22 +136,8 @@ module "hoge" {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := newMockCmd(runAttributeGetCmd, src)
-
-			err := runAttributeSetCmd(cmd, tc.args)
-			stderr := mockErr(cmd)
-			if tc.ok && err != nil {
-				t.Fatalf("unexpected err = %s, stderr: \n%s", err, stderr)
-			}
-
-			stdout := mockOut(cmd)
-			if !tc.ok && err == nil {
-				t.Fatalf("expected to return an error, but no error, stdout: \n%s", stdout)
-			}
-
-			if stdout != tc.want {
-				t.Fatalf("got:\n%s\nwant:\n%s", stdout, tc.want)
-			}
+			cmd := newMockCmd(newAttributeSetCmd(), src)
+			assertMockCmd(t, cmd, tc.args, tc.ok, tc.want)
 		})
 	}
 }
@@ -214,22 +186,8 @@ func TestAttributeRm(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := newMockCmd(runAttributeGetCmd, src)
-
-			err := runAttributeRmCmd(cmd, tc.args)
-			stderr := mockErr(cmd)
-			if tc.ok && err != nil {
-				t.Fatalf("unexpected err = %s, stderr: \n%s", err, stderr)
-			}
-
-			stdout := mockOut(cmd)
-			if !tc.ok && err == nil {
-				t.Fatalf("expected to return an error, but no error, stdout: \n%s", stdout)
-			}
-
-			if stdout != tc.want {
-				t.Fatalf("got:\n%s\nwant:\n%s", stdout, tc.want)
-			}
+			cmd := newMockCmd(newAttributeRmCmd(), src)
+			assertMockCmd(t, cmd, tc.args, tc.ok, tc.want)
 		})
 	}
 }

--- a/cmd/block_test.go
+++ b/cmd/block_test.go
@@ -52,22 +52,8 @@ provider "aws" {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := newMockCmd(runBlockGetCmd, src)
-
-			err := runBlockGetCmd(cmd, tc.args)
-			stderr := mockErr(cmd)
-			if tc.ok && err != nil {
-				t.Fatalf("unexpected err = %s, stderr: \n%s", err, stderr)
-			}
-
-			stdout := mockOut(cmd)
-			if !tc.ok && err == nil {
-				t.Fatalf("expected to return an error, but no error, stdout: \n%s", stdout)
-			}
-
-			if stdout != tc.want {
-				t.Fatalf("got:\n%s\nwant:\n%s", stdout, tc.want)
-			}
+			cmd := newMockCmd(newBlockGetCmd(), src)
+			assertMockCmd(t, cmd, tc.args, tc.ok, tc.want)
 		})
 	}
 }
@@ -129,22 +115,8 @@ resource "aws_security_group" "test2" {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := newMockCmd(runBlockGetCmd, src)
-
-			err := runBlockMvCmd(cmd, tc.args)
-			stderr := mockErr(cmd)
-			if tc.ok && err != nil {
-				t.Fatalf("unexpected err = %s, stderr: \n%s", err, stderr)
-			}
-
-			stdout := mockOut(cmd)
-			if !tc.ok && err == nil {
-				t.Fatalf("expected to return an error, but no error, stdout: \n%s", stdout)
-			}
-
-			if stdout != tc.want {
-				t.Fatalf("got:\n%s\nwant:\n%s", stdout, tc.want)
-			}
+			cmd := newMockCmd(newBlockMvCmd(), src)
+			assertMockCmd(t, cmd, tc.args, tc.ok, tc.want)
 		})
 	}
 }
@@ -180,11 +152,13 @@ resource "aws_security_group" "fuga" {
 
 	cases := []struct {
 		name string
+		args []string
 		ok   bool
 		want string
 	}{
 		{
 			name: "simple",
+			args: []string{},
 			ok:   true,
 			want: `terraform
 provider.aws
@@ -196,23 +170,8 @@ resource.aws_security_group.fuga
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := newMockCmd(runBlockGetCmd, src)
-
-			args := []string{}
-			err := runBlockListCmd(cmd, args)
-			stderr := mockErr(cmd)
-			if tc.ok && err != nil {
-				t.Fatalf("unexpected err = %s, stderr: \n%s", err, stderr)
-			}
-
-			stdout := mockOut(cmd)
-			if !tc.ok && err == nil {
-				t.Fatalf("expected to return an error, but no error, stdout: \n%s", stdout)
-			}
-
-			if stdout != tc.want {
-				t.Fatalf("got:\n%s\nwant:\n%s", stdout, tc.want)
-			}
+			cmd := newMockCmd(newBlockListCmd(), src)
+			assertMockCmd(t, cmd, tc.args, tc.ok, tc.want)
 		})
 	}
 }
@@ -264,22 +223,8 @@ data "aws_security_group" "fuga" {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := newMockCmd(runBlockGetCmd, src)
-
-			err := runBlockRmCmd(cmd, tc.args)
-			stderr := mockErr(cmd)
-			if tc.ok && err != nil {
-				t.Fatalf("unexpected err = %s, stderr: \n%s", err, stderr)
-			}
-
-			stdout := mockOut(cmd)
-			if !tc.ok && err == nil {
-				t.Fatalf("expected to return an error, but no error, stdout: \n%s", stdout)
-			}
-
-			if stdout != tc.want {
-				t.Fatalf("got:\n%s\nwant:\n%s", stdout, tc.want)
-			}
+			cmd := newMockCmd(newBlockRmCmd(), src)
+			assertMockCmd(t, cmd, tc.args, tc.ok, tc.want)
 		})
 	}
 }
@@ -365,26 +310,8 @@ func TestBlockAppend(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := newMockCmdWithFlag(newBlockAppendCmd(), src)
-			cmdFlags := cmd.Flags()
-			if err := cmdFlags.Parse(tc.args); err != nil {
-				t.Fatalf("failed to parse arguments: %s", err)
-			}
-
-			err := runBlockAppendCmd(cmd, cmdFlags.Args())
-			stderr := mockErr(cmd)
-			if tc.ok && err != nil {
-				t.Fatalf("unexpected err = %s, stderr: \n%s", err, stderr)
-			}
-
-			stdout := mockOut(cmd)
-			if !tc.ok && err == nil {
-				t.Fatalf("expected to return an error, but no error, stdout: \n%s", stdout)
-			}
-
-			if stdout != tc.want {
-				t.Fatalf("got:\n%s\nwant:\n%s", stdout, tc.want)
-			}
+			cmd := newMockCmd(newBlockAppendCmd(), src)
+			assertMockCmd(t, cmd, tc.args, tc.ok, tc.want)
 		})
 	}
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,43 +1,28 @@
 package cmd
 
 import (
-	"regexp"
 	"testing"
 )
 
 func TestVersion(t *testing.T) {
 	cases := []struct {
-		name   string
-		args   []string
-		ok     bool
-		wantRe *regexp.Regexp
+		name string
+		args []string
+		ok   bool
+		want string
 	}{
 		{
-			name:   "simple",
-			args:   []string{},
-			ok:     true,
-			wantRe: regexp.MustCompile(`[0-9]+(\.[0-9]+)*(-.*)*`),
+			name: "simple",
+			args: []string{},
+			ok:   true,
+			want: Version + "\n",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := newMockCmd(runVersionCmd, "")
-
-			err := runVersionCmd(cmd, tc.args)
-			stderr := mockErr(cmd)
-			if tc.ok && err != nil {
-				t.Fatalf("unexpected err = %s, stderr: \n%s", err, stderr)
-			}
-
-			stdout := mockOut(cmd)
-			if !tc.ok && err == nil {
-				t.Fatalf("expected to return an error, but no error, stdout: \n%s", stdout)
-			}
-
-			if !tc.wantRe.MatchString(stdout) {
-				t.Fatalf("got:\n%s\nwantRe:\n%s", stdout, tc.wantRe)
-			}
+			cmd := newMockCmd(newVersionCmd(), "")
+			assertMockCmd(t, cmd, tc.args, tc.ok, tc.want)
 		})
 	}
 }


### PR DESCRIPTION
We introduced some argument flag testing in #8, but it should be available for all commands.

Add assertMockCmd() which is a high-level test helper to run a given mock command with arguments and check if an error and its stdout are expected.