### PR TITLE
Fix binary compatibility issue for alpine

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,8 @@ builds:
     ldflags:
       - -s -w
       - -X github.com/minamijoyo/hcledit/cmd.Version={{.Version}}
+    env:
+      - CGO_ENABLED=0
 release:
   prerelease: auto
 changelog:


### PR DESCRIPTION
Fixes #10

The alpine doesn't have glibc, so we need to build with static link.