### PR TITLE
Add attribute append command

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Usage:
   hcledit attribute [command]
 
 Available Commands:
+  append      Append attribute
   get         Get attribute
   rm          Remove attribute
   set         Set attribute
@@ -113,6 +114,18 @@ $ cat tmp/attr.hcl | hcledit attribute rm resource.foo.bar.attr1
 resource "foo" "bar" {
   nested {
     attr2 = "val2"
+  }
+}
+```
+
+```
+$ cat tmp/attr.hcl | hcledit attribute append resource.foo.bar.nested.attr3 '"val3"' --newline
+resource "foo" "bar" {
+  attr1 = "val1"
+  nested {
+    attr2 = "val2"
+
+    attr3 = "val3"
   }
 }
 ```

--- a/cmd/attribute.go
+++ b/cmd/attribute.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/minamijoyo/hcledit/editor"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func init() {
@@ -24,6 +25,7 @@ func newAttributeCmd() *cobra.Command {
 		newAttributeGetCmd(),
 		newAttributeSetCmd(),
 		newAttributeRmCmd(),
+		newAttributeAppendCmd(),
 	)
 
 	return cmd
@@ -108,4 +110,40 @@ func runAttributeRmCmd(cmd *cobra.Command, args []string) error {
 	address := args[0]
 
 	return editor.RemoveAttribute(cmd.InOrStdin(), cmd.OutOrStdout(), "-", address)
+}
+
+func newAttributeAppendCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "append <ADDRESS> <VALUE>",
+		Short: "Append attribute",
+		Long: `Append a new attribute at a given address
+
+Arguments:
+  ADDRESS          An address of attribute to append.
+  VALUE            A new value of attribute.
+                   The value is set literally, even if references or expressions.
+                   Thus, if you want to set a string literal "hoge", be sure to
+                   escape double quotes so that they are not discarded by your shell.
+                   e.g.) hcledit attribute append aaa.bbb.ccc '"hoge"'
+`,
+		RunE: runAttributeAppendCmd,
+	}
+
+	flags := cmd.Flags()
+	flags.Bool("newline", false, "Append a new line before a new attribute")
+	viper.BindPFlag("attribute.append.newline", flags.Lookup("newline"))
+
+	return cmd
+}
+
+func runAttributeAppendCmd(cmd *cobra.Command, args []string) error {
+	if len(args) != 2 {
+		return fmt.Errorf("expected 2 argument, but got %d arguments", len(args))
+	}
+
+	address := args[0]
+	value := args[1]
+	newline := viper.GetBool("attribute.append.newline")
+
+	return editor.AppendAttribute(cmd.InOrStdin(), cmd.OutOrStdout(), "-", address, value, newline)
 }

--- a/editor/attribute_append.go
+++ b/editor/attribute_append.go
@@ -1,0 +1,82 @@
+package editor
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// AppendAttribute reads HCL from io.Reader, and appends a new attribute to a
+// given address, and writes the updated HCL to io.Writer.
+// If a matched block not found, nothing happens.
+// If the given attribute already exists, it returns an error.
+// If a newline flag is true, it also appends a newline before the new attribute.
+// Note that a filename is used only for an error message.
+// If an error occurs, Nothing is written to the output stream.
+func AppendAttribute(r io.Reader, w io.Writer, filename string, address string, value string, newline bool) error {
+	e := &Editor{
+		source: &parser{filename: filename},
+		filters: []Filter{
+			&attributeAppend{
+				address: address,
+				value:   value,
+				newline: newline,
+			},
+		},
+		sink: &formater{},
+	}
+
+	return e.Apply(r, w)
+}
+
+// attributeAppend is a filter implementation for attribute.
+type attributeAppend struct {
+	address string
+	value   string
+	newline bool
+}
+
+// Filter reads HCL and appends a new attribute to a given address.
+func (f *attributeAppend) Filter(inFile *hclwrite.File) (*hclwrite.File, error) {
+	attrName := f.address
+	body := inFile.Body()
+
+	a := strings.Split(f.address, ".")
+	if len(a) > 1 {
+		// if address contains dots, the last element is an attribute name,
+		// and the rest is the address of the block.
+		attrName = a[len(a)-1]
+		blockAddr := strings.Join(a[:len(a)-1], ".")
+		blocks, err := findLongestMatchingBlocks(body, blockAddr)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(blocks) == 0 {
+			// not found
+			return inFile, nil
+		}
+
+		// Use first matching one.
+		body = blocks[0].Body()
+		if body.GetAttribute(attrName) != nil {
+			return nil, fmt.Errorf("attribute already exists: %s", f.address)
+		}
+	}
+
+	// To delegate expression parsing to the hclwrite parser,
+	// We build a new expression and set back to the attribute by tokens.
+	expr, err := buildExpression(attrName, f.value)
+	if err != nil {
+		return nil, err
+	}
+
+	if f.newline {
+		body.AppendNewline()
+	}
+	body.SetAttributeRaw(attrName, expr.BuildTokens(nil))
+
+	return inFile, nil
+}

--- a/editor/attribute_append_test.go
+++ b/editor/attribute_append_test.go
@@ -1,0 +1,127 @@
+package editor
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestAttributeAppend(t *testing.T) {
+	cases := []struct {
+		name    string
+		src     string
+		address string
+		value   string
+		newline bool
+		ok      bool
+		want    string
+	}{
+		{
+			name: "simple top level attribute",
+			src: `
+a0 = v0
+`,
+			address: "a1",
+			value:   "v1",
+			newline: false,
+			ok:      true,
+			want: `
+a0 = v0
+a1 = v1
+`,
+		},
+		{
+			name: "attribute in block",
+			src: `
+a0 = v0
+b1 "l1" {
+  a1 = v1
+}
+`,
+			address: "b1.l1.a2",
+			value:   "v2",
+			newline: false,
+			ok:      true,
+			want: `
+a0 = v0
+b1 "l1" {
+  a1 = v1
+  a2 = v2
+}
+`,
+		},
+		{
+			name: "attribute in block (with newline)",
+			src: `
+a0 = v0
+b1 "l1" {
+  a1 = v1
+}
+`,
+			address: "b1.l1.a2",
+			value:   "v2",
+			newline: true,
+			ok:      true,
+			want: `
+a0 = v0
+b1 "l1" {
+  a1 = v1
+
+  a2 = v2
+}
+`,
+		},
+		{
+			name: "block not found (noop)",
+			src: `
+a0 = v0
+b1 "l1" {
+  a1 = v1
+}
+`,
+			address: "b2.l1.a1",
+			value:   "v2",
+			newline: false,
+			ok:      true,
+			want: `
+a0 = v0
+b1 "l1" {
+  a1 = v1
+}
+`,
+		},
+		{
+			name: "attribute already exists (error)",
+			src: `
+a0 = v0
+b1 "l1" {
+  a1 = v1
+}
+`,
+			address: "b1.l1.a1",
+			value:   "v2",
+			newline: false,
+			ok:      false,
+			want:    ``,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inStream := bytes.NewBufferString(tc.src)
+			outStream := new(bytes.Buffer)
+			err := AppendAttribute(inStream, outStream, "test", tc.address, tc.value, tc.newline)
+			if tc.ok && err != nil {
+				t.Fatalf("unexpected err = %s", err)
+			}
+
+			got := outStream.String()
+			if !tc.ok && err == nil {
+				t.Fatalf("expected to return an error, but no error, outStream: \n%s", got)
+			}
+
+			if got != tc.want {
+				t.Fatalf("got:\n%s\nwant:\n%s", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In #8, I added block append command. However it can add only an empty body for simplicity. Of course, that's not make sense.
In this PR, I also added attribute append command, which is a missing parts for appending a new block in a real use-case.

It allows us to append a new attribute to a given address.
If a matched block not found, nothing happens.
If the given attribute already exists, it returns an error.
If a newline flag is true, it also appends a newline before the new attribute.

```
$ go run main.go attribute append --help
Append a new attribute at a given address

Arguments:
  ADDRESS          An address of attribute to append.
  VALUE            A new value of attribute.
                   The value is set literally, even if references or expressions.
                   Thus, if you want to set a string literal "hoge", be sure to
                   escape double quotes so that they are not discarded by your shell.
                   e.g.) hcledit attribute append aaa.bbb.ccc '"hoge"'

Usage:
  hcledit attribute append <ADDRESS> <VALUE> [flags]

Flags:
  -h, --help      help for append
      --newline   Append a new line before a new attribute
```

```
$ cat tmp/attr.hcl
resource "foo" "bar" {
  attr1 = "val1"
  nested {
    attr2 = "val2"
  }
}
```

```
$ cat tmp/attr.hcl | go run main.go attribute append resource.foo.bar.nested.attr3 '"val3"' --newline
resource "foo" "bar" {
  attr1 = "val1"
  nested {
    attr2 = "val2"

    attr3 = "val3"
  }
}
```