### PR TITLE
Add fmt command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - Available operations:
   - block append/get/list/mv/rm
   - attribute append/get/rm/set
+  - fmt
 
 The hcledit focuses on editing HCL with command line, doesn't aim for generic query tools. It was originally born for refactoring Terraform configurations, but it's not limited to specific applications.
 The HCL specification is somewhat generic, so usability takes precedence over strictness if there is room for interpreting meanings in the schemaless approach.
@@ -55,6 +56,7 @@ Usage:
 Available Commands:
   attribute   Edit attribute
   block       Edit block
+  fmt         Format file
   help        Help about any command
   version     Print version
 
@@ -210,6 +212,37 @@ resource "foo" "bar" {
 
 resource "foo" "baz" {
   attr1 = "val2"
+}
+```
+
+### fmt
+
+```
+$ hcledit fmt --help
+Format a file to a caconical style
+
+Usage:
+  hcledit fmt [flags]
+
+Flags:
+  -h, --help   help for fmt
+```
+
+Given the following file:
+
+```
+$ cat tmp/fmt.hcl
+resource "foo" "bar" {
+  attr1 = "val1"
+  attr2="val2"
+}
+```
+
+```
+$ cat tmp/fmt.hcl | hcledit fmt
+resource "foo" "bar" {
+  attr1 = "val1"
+  attr2 = "val2"
 }
 ```
 

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/minamijoyo/hcledit/editor"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.AddCommand(newFmtCmd())
+}
+
+func newFmtCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "fmt",
+		Short: "Format file",
+		Long:  "Format a file to a caconical style",
+		RunE:  runFmtCmd,
+	}
+
+	return cmd
+}
+
+func runFmtCmd(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return fmt.Errorf("expected no argument, but got %d arguments", len(args))
+	}
+
+	return editor.Format(cmd.InOrStdin(), cmd.OutOrStdout(), "-")
+}

--- a/cmd/fmt_test.go
+++ b/cmd/fmt_test.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestFmt(t *testing.T) {
+
+	cases := []struct {
+		name string
+		src  string
+		args []string
+		ok   bool
+		want string
+	}{
+		{
+			name: "unformatted",
+			src: `
+resource "foo" "bar" {
+  attr1 = "val1"
+  attr2="val2"
+}
+`,
+			args: []string{},
+			ok:   true,
+			want: `
+resource "foo" "bar" {
+  attr1 = "val1"
+  attr2 = "val2"
+}
+`,
+		},
+		{
+			name: "syntax error",
+			src: `
+resource "foo" "bar" {
+  attr1 = "val1"
+`,
+			args: []string{},
+			ok:   false,
+			want: "",
+		},
+		{
+			name: "too many args",
+			src:  "",
+			args: []string{"foo"},
+			ok:   false,
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newMockCmd(newFmtCmd(), tc.src)
+			assertMockCmd(t, cmd, tc.args, tc.ok, tc.want)
+		})
+	}
+}

--- a/editor/fmt.go
+++ b/editor/fmt.go
@@ -1,0 +1,18 @@
+package editor
+
+import (
+	"io"
+)
+
+// Format reads HCL from io.Reader, and writes formatted contents to io.Writer.
+// Note that a filename is used only for an error message.
+// If an error occurs, nothing is written to the output stream.
+func Format(r io.Reader, w io.Writer, filename string) error {
+	e := &Editor{
+		source:  &parser{filename: filename},
+		filters: []Filter{}, // noop
+		sink:    &formater{},
+	}
+
+	return e.Apply(r, w)
+}

--- a/editor/fmt_test.go
+++ b/editor/fmt_test.go
@@ -1,0 +1,77 @@
+package editor
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestFormat(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		ok   bool
+		want string
+	}{
+		{
+			name: "unformatted",
+			src: `
+  b1   {
+  a1 = v1
+	a2=v2
+}
+`,
+			ok: true,
+			want: `
+b1 {
+  a1 = v1
+  a2 = v2
+}
+`,
+		},
+		{
+			name: "formatted",
+			src: `
+b1 {
+  a1 = v1
+  a2 = v2
+}
+`,
+			ok: true,
+			want: `
+b1 {
+  a1 = v1
+  a2 = v2
+}
+`,
+		},
+		{
+			name: "syntax error",
+			src: `
+b1 {
+  a1 = v1
+`,
+			ok:   false,
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inStream := bytes.NewBufferString(tc.src)
+			outStream := new(bytes.Buffer)
+			err := Format(inStream, outStream, "test")
+			if tc.ok && err != nil {
+				t.Fatalf("unexpected err = %s", err)
+			}
+
+			got := outStream.String()
+			if !tc.ok && err == nil {
+				t.Fatalf("expected to return an error, but no error, outStream: \n%s", got)
+			}
+
+			if got != tc.want {
+				t.Fatalf("got:\n%s\nwant:\n%s", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #13

Add a fmt command similar to `terraform fmt` but for generic HCL.
It's intended to use for format or syntax check.

```
$ go run main.go fmt --help
Format a file to a caconical style

Usage:
  hcledit fmt [flags]

Flags:
  -h, --help   help for fmt
```

```
$ cat tmp/fmt_unmformatted.hcl
resource "foo" "bar" {
  attr1 = "val1"
  attr2="val2"
}

$ cat tmp/fmt_unmformatted.hcl | go run main.go fmt
resource "foo" "bar" {
  attr1 = "val1"
  attr2 = "val2"
}

$ echo $?
0
```

```
$ cat tmp/fmt_syntax_error.hcl
resource "foo" "bar" {
  attr1 = "val1"

$ cat tmp/fmt_syntax_error.hcl | go run main.go fmt
failed to parse input: -:3,1-1: Argument or block definition required; An argument or block definition is required here.
exit status 1

$ echo $?
1
```