### PR TITLE
Add support for getting nested block

### DIFF
--- a/editor/filter_block_get.go
+++ b/editor/filter_block_get.go
@@ -28,7 +28,18 @@ func (f *BlockGetFilter) Filter(inFile *hclwrite.File) (*hclwrite.File, error) {
 		return nil, err
 	}
 
+	// find the top-level blocks first.
 	matched := findBlocks(inFile.Body(), typeName, labels)
+	if len(matched) == 0 {
+		// If not found, then find nested blocks.
+		// I'll reuse the findLongestMatchingBlocks to implement it as a compromise for now,
+		// but it doesn't support the wildcard match. There is a bit inconsistency here.
+		// To fix it, we will need to merge implementations of findBlocks and findLongestMatchingBlocks.
+		matched, err = findLongestMatchingBlocks(inFile.Body(), f.address)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	outFile := hclwrite.NewEmptyFile()
 	for i, b := range matched {

--- a/editor/filter_block_get_test.go
+++ b/editor/filter_block_get_test.go
@@ -169,6 +169,77 @@ b1 {
 }
 `,
 		},
+		{
+			name: "nested block",
+			src: `
+b1 {
+  a1 = v1
+  b2 {
+    a2 = v2
+  }
+}
+`,
+			address: "b1.b2",
+			ok:      true,
+			want: `b2 {
+  a2 = v2
+}
+`,
+		},
+		{
+			name: "nested block (extra labels)",
+			src: `
+b1 "l1" {
+  a1 = v1
+  b2 {
+    a2 = v2
+  }
+}
+`,
+			address: "b1.b2",
+			ok:      true,
+			want:    "",
+		},
+		{
+			name: "labels take precedence over nested blocks",
+			src: `
+b1 "b2" {
+  a1 = v1
+  b2 {
+    a1 = v2
+  }
+}
+`,
+			address: "b1.b2",
+			ok:      true,
+			want: `b1 "b2" {
+  a1 = v1
+  b2 {
+    a1 = v2
+  }
+}
+`,
+		},
+		{
+			name: "multi level nested block",
+			src: `
+b1 {
+  a1 = v1
+  b2 {
+    a2 = v2
+    b3 {
+      a3 = v3
+    }
+  }
+}
+`,
+			address: "b1.b2.b3",
+			ok:      true,
+			want: `b3 {
+  a3 = v3
+}
+`,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Partial fix for #21

The previous implementation of the block get command didn't support a nested block. However, it's natural to expect returning the nested block as the same as the attribute in the nested block.

I'll reuse the findLongestMatchingBlocks to implement it as a compromise for now, but it doesn't support the wildcard match. There is a bit inconsistency here. To fix it, we will need to merge implementations of findBlocks and findLongestMatchingBlocks.

```
$ cat tmp/attr.hcl | go run main.go block get resource.foo.bar.nested
nested {
  attr2 = "val2"
}

$ cat tmp/attr.hcl | go run main.go block get resource.foo.bar
resource "foo" "bar" {
  attr1 = "val1"
  nested {
    attr2 = "val2"
  }
}
```