### PR TITLE
Add body get command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@
 - Schemaless: No dependency on specific HCL application binary or schema
 - Support HCL2 (not HCL1)
 - Available operations:
-  - block append/get/list/mv/rm
   - attribute append/get/rm/set
+  - block append/get/list/mv/rm
+  - body get
   - fmt
 
 The hcledit focuses on editing HCL with command line, doesn't aim for generic query tools. It was originally born for refactoring Terraform configurations, but it's not limited to specific applications.
@@ -212,6 +213,44 @@ resource "foo" "bar" {
 
 resource "foo" "baz" {
   attr1 = "val2"
+}
+```
+
+### body
+
+```
+$ hcledit body --help
+Edit body
+
+Usage:
+  hcledit body [flags]
+  hcledit body [command]
+
+Available Commands:
+  get         Get body
+
+Flags:
+  -h, --help   help for body
+
+Use "hcledit body [command] --help" for more information about a command.
+```
+
+Given the following file:
+
+```body.hcl
+resource "foo" "bar" {
+  attr1 = "val1"
+  nested {
+    attr2 = "val2"
+  }
+}
+```
+
+```
+$ cat tmp/body.hcl | hcledit body get resource.foo.bar
+attr1 = "val1"
+nested {
+  attr2 = "val2"
 }
 ```
 

--- a/cmd/body.go
+++ b/cmd/body.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/minamijoyo/hcledit/editor"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.AddCommand(newBodyCmd())
+}
+
+func newBodyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "body",
+		Short: "Edit body",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(
+		newBodyGetCmd(),
+	)
+
+	return cmd
+}
+
+func newBodyGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <ADDRESS>",
+		Short: "Get body",
+		Long: `Get body of first matched block at a given address
+
+Arguments:
+  ADDRESS          An address of block to get.
+`,
+		RunE: runBodyGetCmd,
+	}
+
+	return cmd
+}
+
+func runBodyGetCmd(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("expected 1 argument, but got %d arguments", len(args))
+	}
+
+	address := args[0]
+
+	o := editor.NewEditOperator(editor.NewBodyGetFilter(address))
+	return o.Apply(cmd.InOrStdin(), cmd.OutOrStdout(), "-")
+}

--- a/cmd/body_test.go
+++ b/cmd/body_test.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestBodyGet(t *testing.T) {
+	src := `resource "foo" "bar" {
+  attr1 = "val1"
+  nested {
+    attr2 = "val2"
+  }
+}
+`
+
+	cases := []struct {
+		name string
+		args []string
+		ok   bool
+		want string
+	}{
+		{
+			name: "simple",
+			args: []string{"resource.foo.bar"},
+			ok:   true,
+			want: `attr1 = "val1"
+nested {
+  attr2 = "val2"
+}
+`,
+		},
+		{
+			name: "no match",
+			args: []string{"hoge"},
+			ok:   true,
+			want: "",
+		},
+		{
+			name: "no args",
+			args: []string{},
+			ok:   false,
+			want: "",
+		},
+		{
+			name: "too many args",
+			args: []string{"hoge", "fuga"},
+			ok:   false,
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newMockCmd(newBodyGetCmd(), src)
+			assertMockCmd(t, cmd, tc.args, tc.ok, tc.want)
+		})
+	}
+}

--- a/editor/filter_body_get.go
+++ b/editor/filter_body_get.go
@@ -1,0 +1,53 @@
+package editor
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// BodyGetFilter is a filter implementation for getting body of first matched block.
+type BodyGetFilter struct {
+	address string
+}
+
+var _ Filter = (*BodyGetFilter)(nil)
+
+// NewBodyGetFilter creates a new instance of BodyGetFilter.
+func NewBodyGetFilter(address string) Filter {
+	return &BodyGetFilter{
+		address: address,
+	}
+}
+
+// Filter reads HCL and writes body of first matched block at a given address.
+func (f *BodyGetFilter) Filter(inFile *hclwrite.File) (*hclwrite.File, error) {
+	m := NewMultiFilter([]Filter{
+		NewBlockGetFilter(f.address),
+		&firstBodyFilter{},
+		// body contains a leading NewLine token, it's natural to trim it.
+		&verticalFormatterFilter{},
+	})
+	return m.Filter(inFile)
+}
+
+// firstBodyFilter is a filter implementation for getting body of first block.
+type firstBodyFilter struct {
+}
+
+var _ Filter = (*firstBodyFilter)(nil)
+
+// Filter reads HCL and writes body of first block.
+func (f *firstBodyFilter) Filter(inFile *hclwrite.File) (*hclwrite.File, error) {
+	outFile := hclwrite.NewEmptyFile()
+
+	matched := inFile.Body().Blocks()
+	if len(matched) > 0 {
+		// The current implementation doesn't support index in address format.
+		// Merging body of contents for multiple blocks doesn't make sense,
+		// so we take the first matched block.
+		body := matched[0].Body()
+		tokens := body.BuildTokens(nil)
+		outFile.Body().AppendUnstructuredTokens(tokens)
+	}
+
+	return outFile, nil
+}

--- a/editor/filter_body_get_test.go
+++ b/editor/filter_body_get_test.go
@@ -1,0 +1,141 @@
+package editor
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestBodyGetFilter(t *testing.T) {
+	cases := []struct {
+		name    string
+		src     string
+		address string
+		ok      bool
+		want    string
+	}{
+		{
+			name: "simple",
+			src: `
+a0 = v0
+b1 {
+  a2 = v2
+}
+
+b2 l1 {
+}
+`,
+			address: "b1",
+			ok:      true,
+			want: `a2 = v2
+`,
+		},
+		{
+			name: "no match",
+			src: `
+a0 = v0
+b1 {
+  a2 = v2
+}
+`,
+			address: "foo",
+			ok:      true,
+			want:    "",
+		},
+		{
+			name:    "empty",
+			address: "",
+			ok:      false,
+			want:    "",
+		},
+		{
+			name: "with label",
+			src: `
+b1 {
+  a1 =  v1
+}
+
+b1 l1 {
+  a2 = v2
+}
+`,
+			address: "b1.l1",
+			ok:      true,
+			want: `a2 = v2
+`,
+		},
+		{
+			name: "get first block",
+			src: `
+b1 {
+  a1 =  v1
+}
+
+b1 l1 {
+  a2 = v2
+}
+
+b1 l1 {
+  a3 = v3
+}
+`,
+			address: "b1.l1",
+			ok:      true,
+			want: `a2 = v2
+`,
+		},
+		{
+			name: "get inside block",
+			src: `
+b1 {
+  a1 = v1
+  b2 {
+    a2 = v2
+  }
+}
+`,
+			address: "b1.b2",
+			ok:      true,
+			want: `a2 = v2
+`,
+		},
+		{
+			name: "get outside block",
+			src: `
+b1 {
+  a1 = v1
+  b2 {
+    a2 = v2
+  }
+}
+`,
+			address: "b1",
+			ok:      true,
+			want: `a1 = v1
+b2 {
+  a2 = v2
+}
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inStream := bytes.NewBufferString(tc.src)
+			outStream := new(bytes.Buffer)
+			o := NewEditOperator(NewBodyGetFilter(tc.address))
+			err := o.Apply(inStream, outStream, "test")
+			if tc.ok && err != nil {
+				t.Fatalf("unexpected err = %s", err)
+			}
+
+			got := outStream.String()
+			if !tc.ok && err == nil {
+				t.Fatalf("expected to return an error, but no error, outStream: \n%s", got)
+			}
+
+			if got != tc.want {
+				t.Fatalf("got:\n%s\nwant:\n%s", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #21

Add a new command `hcledit body get`, which gets body of first matched block at a given address.

The current implementation doesn't support index in address format. Merging body of contents for multiple blocks doesn't make sense, so we take the first matched block.

```
$ go run main.go body get --help
Get body of first matched block at a given address

Arguments:
  ADDRESS          An address of block to get.

Usage:
  hcledit body get <ADDRESS> [flags]

Flags:
  -h, --help   help for get
```

```
$ cat tmp/body.hcl
resource "foo" "bar" {
  attr1 = "val1"
  nested {
    attr2 = "val2"
  }
}

$ cat tmp/body.hcl | go run main.go body get resource.foo.bar.nested
attr2 = "val2"

$ cat tmp/body.hcl | go run main.go body get resource.foo.bar
attr1 = "val1"
nested {
  attr2 = "val2"
}
```

Note: In the original feature request in #21, the expected behavior contains the outer brackets `{}`, however, according to the HCL spec, the outer brackets don't belong to the body.

https://github.com/hashicorp/hcl/blob/v2.9.1/hclsyntax/spec.md#structural-elements

So we should not include them in the outputs.