### PR TITLE
Skip formatter if filter didn't change contents

### DIFF
--- a/cmd/attribute.go
+++ b/cmd/attribute.go
@@ -53,8 +53,8 @@ func runAttributeGetCmd(cmd *cobra.Command, args []string) error {
 
 	address := args[0]
 
-	o := editor.NewDeriveOperator(editor.NewAttributeGetSink(address))
-	return o.Apply(cmd.InOrStdin(), cmd.OutOrStdout(), "-")
+	sink := editor.NewAttributeGetSink(address)
+	return editor.DeriveStream(cmd.InOrStdin(), cmd.OutOrStdout(), "-", sink)
 }
 
 func newAttributeSetCmd() *cobra.Command {
@@ -85,8 +85,8 @@ func runAttributeSetCmd(cmd *cobra.Command, args []string) error {
 	address := args[0]
 	value := args[1]
 
-	o := editor.NewEditOperator(editor.NewAttributeSetFilter(address, value))
-	return o.Apply(cmd.InOrStdin(), cmd.OutOrStdout(), "-")
+	filter := editor.NewAttributeSetFilter(address, value)
+	return editor.EditStream(cmd.InOrStdin(), cmd.OutOrStdout(), "-", filter)
 }
 
 func newAttributeRmCmd() *cobra.Command {
@@ -111,8 +111,8 @@ func runAttributeRmCmd(cmd *cobra.Command, args []string) error {
 
 	address := args[0]
 
-	o := editor.NewEditOperator(editor.NewAttributeRemoveFilter(address))
-	return o.Apply(cmd.InOrStdin(), cmd.OutOrStdout(), "-")
+	filter := editor.NewAttributeRemoveFilter(address)
+	return editor.EditStream(cmd.InOrStdin(), cmd.OutOrStdout(), "-", filter)
 }
 
 func newAttributeAppendCmd() *cobra.Command {
@@ -148,6 +148,6 @@ func runAttributeAppendCmd(cmd *cobra.Command, args []string) error {
 	value := args[1]
 	newline := viper.GetBool("attribute.append.newline")
 
-	o := editor.NewEditOperator(editor.NewAttributeAppendFilter(address, value, newline))
-	return o.Apply(cmd.InOrStdin(), cmd.OutOrStdout(), "-")
+	filter := editor.NewAttributeAppendFilter(address, value, newline)
+	return editor.EditStream(cmd.InOrStdin(), cmd.OutOrStdout(), "-", filter)
 }

--- a/cmd/block.go
+++ b/cmd/block.go
@@ -54,8 +54,8 @@ func runBlockGetCmd(cmd *cobra.Command, args []string) error {
 
 	address := args[0]
 
-	o := editor.NewEditOperator(editor.NewBlockGetFilter(address))
-	return o.Apply(cmd.InOrStdin(), cmd.OutOrStdout(), "-")
+	filter := editor.NewBlockGetFilter(address)
+	return editor.EditStream(cmd.InOrStdin(), cmd.OutOrStdout(), "-", filter)
 }
 
 func newBlockMvCmd() *cobra.Command {
@@ -82,8 +82,8 @@ func runBlockMvCmd(cmd *cobra.Command, args []string) error {
 	from := args[0]
 	to := args[1]
 
-	o := editor.NewEditOperator(editor.NewBlockRenameFilter(from, to))
-	return o.Apply(cmd.InOrStdin(), cmd.OutOrStdout(), "-")
+	filter := editor.NewBlockRenameFilter(from, to)
+	return editor.EditStream(cmd.InOrStdin(), cmd.OutOrStdout(), "-", filter)
 }
 
 func newBlockListCmd() *cobra.Command {
@@ -101,8 +101,8 @@ func runBlockListCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("expected 0 argument, but got %d arguments", len(args))
 	}
 
-	o := editor.NewDeriveOperator(editor.NewBlockListSink())
-	return o.Apply(cmd.InOrStdin(), cmd.OutOrStdout(), "-")
+	sink := editor.NewBlockListSink()
+	return editor.DeriveStream(cmd.InOrStdin(), cmd.OutOrStdout(), "-", sink)
 }
 
 func newBlockRmCmd() *cobra.Command {
@@ -127,8 +127,8 @@ func runBlockRmCmd(cmd *cobra.Command, args []string) error {
 
 	address := args[0]
 
-	o := editor.NewEditOperator(editor.NewBlockRemoveFilter(address))
-	return o.Apply(cmd.InOrStdin(), cmd.OutOrStdout(), "-")
+	filter := editor.NewBlockRemoveFilter(address)
+	return editor.EditStream(cmd.InOrStdin(), cmd.OutOrStdout(), "-", filter)
 }
 
 func newBlockAppendCmd() *cobra.Command {
@@ -160,6 +160,6 @@ func runBlockAppendCmd(cmd *cobra.Command, args []string) error {
 	child := args[1]
 	newline := viper.GetBool("block.append.newline")
 
-	o := editor.NewEditOperator(editor.NewBlockAppendFilter(parent, child, newline))
-	return o.Apply(cmd.InOrStdin(), cmd.OutOrStdout(), "-")
+	filter := editor.NewBlockAppendFilter(parent, child, newline)
+	return editor.EditStream(cmd.InOrStdin(), cmd.OutOrStdout(), "-", filter)
 }

--- a/cmd/body.go
+++ b/cmd/body.go
@@ -49,6 +49,6 @@ func runBodyGetCmd(cmd *cobra.Command, args []string) error {
 
 	address := args[0]
 
-	o := editor.NewEditOperator(editor.NewBodyGetFilter(address))
-	return o.Apply(cmd.InOrStdin(), cmd.OutOrStdout(), "-")
+	filter := editor.NewBodyGetFilter(address)
+	return editor.EditStream(cmd.InOrStdin(), cmd.OutOrStdout(), "-", filter)
 }

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -28,6 +28,6 @@ func runFmtCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	// Although fmt is actually not a derivation, we intentionally abuse it here for convenience.
-	o := editor.NewDeriveOperator(editor.NewFormatterSink())
-	return o.Apply(cmd.InOrStdin(), cmd.OutOrStdout(), "-")
+	sink := editor.NewFormatterSink()
+	return editor.DeriveStream(cmd.InOrStdin(), cmd.OutOrStdout(), "-", sink)
 }

--- a/editor/filter_attribute_append_test.go
+++ b/editor/filter_attribute_append_test.go
@@ -1,7 +1,6 @@
 package editor
 
 import (
-	"bytes"
 	"testing"
 )
 
@@ -107,16 +106,13 @@ b1 "l1" {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			inStream := bytes.NewBufferString(tc.src)
-			outStream := new(bytes.Buffer)
-
 			o := NewEditOperator(NewAttributeAppendFilter(tc.address, tc.value, tc.newline))
-			err := o.Apply(inStream, outStream, "test")
+			output, err := o.Apply([]byte(tc.src), "test")
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err = %s", err)
 			}
 
-			got := outStream.String()
+			got := string(output)
 			if !tc.ok && err == nil {
 				t.Fatalf("expected to return an error, but no error, outStream: \n%s", got)
 			}

--- a/editor/filter_attribute_remove_test.go
+++ b/editor/filter_attribute_remove_test.go
@@ -1,7 +1,6 @@
 package editor
 
 import (
-	"bytes"
 	"testing"
 )
 
@@ -105,15 +104,13 @@ b1 "l1" {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			inStream := bytes.NewBufferString(tc.src)
-			outStream := new(bytes.Buffer)
 			o := NewEditOperator(NewAttributeRemoveFilter(tc.address))
-			err := o.Apply(inStream, outStream, "test")
+			output, err := o.Apply([]byte(tc.src), "test")
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err = %s", err)
 			}
 
-			got := outStream.String()
+			got := string(output)
 			if !tc.ok && err == nil {
 				t.Fatalf("expected to return an error, but no error, outStream: \n%s", got)
 			}

--- a/editor/filter_attribute_set_test.go
+++ b/editor/filter_attribute_set_test.go
@@ -1,7 +1,6 @@
 package editor
 
 import (
-	"bytes"
 	"testing"
 )
 
@@ -156,15 +155,13 @@ b1 "l1" {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			inStream := bytes.NewBufferString(tc.src)
-			outStream := new(bytes.Buffer)
 			o := NewEditOperator(NewAttributeSetFilter(tc.address, tc.value))
-			err := o.Apply(inStream, outStream, "test")
+			output, err := o.Apply([]byte(tc.src), "test")
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err = %s", err)
 			}
 
-			got := outStream.String()
+			got := string(output)
 			if !tc.ok && err == nil {
 				t.Fatalf("expected to return an error, but no error, outStream: \n%s", got)
 			}

--- a/editor/filter_block_append_test.go
+++ b/editor/filter_block_append_test.go
@@ -1,7 +1,6 @@
 package editor
 
 import (
-	"bytes"
 	"testing"
 )
 
@@ -157,15 +156,13 @@ b1 {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			inStream := bytes.NewBufferString(tc.src)
-			outStream := new(bytes.Buffer)
 			o := NewEditOperator(NewBlockAppendFilter(tc.parent, tc.child, tc.newline))
-			err := o.Apply(inStream, outStream, "test")
+			output, err := o.Apply([]byte(tc.src), "test")
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err = %s", err)
 			}
 
-			got := outStream.String()
+			got := string(output)
 			if !tc.ok && err == nil {
 				t.Fatalf("expected to return an error, but no error, outStream: \n%s", got)
 			}

--- a/editor/filter_block_get_test.go
+++ b/editor/filter_block_get_test.go
@@ -1,7 +1,6 @@
 package editor
 
 import (
-	"bytes"
 	"testing"
 )
 
@@ -244,15 +243,13 @@ b1 {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			inStream := bytes.NewBufferString(tc.src)
-			outStream := new(bytes.Buffer)
 			o := NewEditOperator(NewBlockGetFilter(tc.address))
-			err := o.Apply(inStream, outStream, "test")
+			output, err := o.Apply([]byte(tc.src), "test")
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err = %s", err)
 			}
 
-			got := outStream.String()
+			got := string(output)
 			if !tc.ok && err == nil {
 				t.Fatalf("expected to return an error, but no error, outStream: \n%s", got)
 			}

--- a/editor/filter_block_remove_test.go
+++ b/editor/filter_block_remove_test.go
@@ -1,7 +1,6 @@
 package editor
 
 import (
-	"bytes"
 	"testing"
 )
 
@@ -124,15 +123,13 @@ b1 l1 {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			inStream := bytes.NewBufferString(tc.src)
-			outStream := new(bytes.Buffer)
 			o := NewEditOperator(NewBlockRemoveFilter(tc.address))
-			err := o.Apply(inStream, outStream, "test")
+			output, err := o.Apply([]byte(tc.src), "test")
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err = %s", err)
 			}
 
-			got := outStream.String()
+			got := string(output)
 			if !tc.ok && err == nil {
 				t.Fatalf("expected to return an error, but no error, outStream: \n%s", got)
 			}

--- a/editor/filter_block_rename_test.go
+++ b/editor/filter_block_rename_test.go
@@ -1,7 +1,6 @@
 package editor
 
 import (
-	"bytes"
 	"testing"
 )
 
@@ -40,15 +39,13 @@ b2 "l2" {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			inStream := bytes.NewBufferString(tc.src)
-			outStream := new(bytes.Buffer)
 			o := NewEditOperator(NewBlockRenameFilter(tc.from, tc.to))
-			err := o.Apply(inStream, outStream, "test")
+			output, err := o.Apply([]byte(tc.src), "test")
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err = %s", err)
 			}
 
-			got := outStream.String()
+			got := string(output)
 			if !tc.ok && err == nil {
 				t.Fatalf("expected to return an error, but no error, outStream: \n%s", got)
 			}

--- a/editor/filter_body_get_test.go
+++ b/editor/filter_body_get_test.go
@@ -1,7 +1,6 @@
 package editor
 
 import (
-	"bytes"
 	"testing"
 )
 
@@ -120,15 +119,13 @@ b2 {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			inStream := bytes.NewBufferString(tc.src)
-			outStream := new(bytes.Buffer)
 			o := NewEditOperator(NewBodyGetFilter(tc.address))
-			err := o.Apply(inStream, outStream, "test")
+			output, err := o.Apply([]byte(tc.src), "test")
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err = %s", err)
 			}
 
-			got := outStream.String()
+			got := string(output)
 			if !tc.ok && err == nil {
 				t.Fatalf("expected to return an error, but no error, outStream: \n%s", got)
 			}

--- a/editor/formatter_default.go
+++ b/editor/formatter_default.go
@@ -1,0 +1,23 @@
+package editor
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// DefaultFormatter is a default Formatter implementation for formatting HCL.
+type DefaultFormatter struct {
+}
+
+var _ Formatter = (*DefaultFormatter)(nil)
+
+// NewDefaultFormatter creates a new instance of DefaultFormatter.
+func NewDefaultFormatter() Formatter {
+	return &DefaultFormatter{}
+}
+
+// Format reads HCL, formats tokens and writes formatted contents.
+func (f *DefaultFormatter) Format(inFile *hclwrite.File) ([]byte, error) {
+	raw := inFile.BuildTokens(nil).Bytes()
+	out := hclwrite.Format(raw)
+	return out, nil
+}

--- a/editor/operator.go
+++ b/editor/operator.go
@@ -1,8 +1,6 @@
 package editor
 
 import (
-	"io"
-
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
 
@@ -11,10 +9,10 @@ import (
 // but also for deriving such as listing.
 // They need similar but different implementations.
 type Operator interface {
-	// Apply reads an input stream, apply some operations, and writes an output stream.
-	// The input and output streams contain arbitrary bytes (maybe HCL or not).
+	// Apply reads input bytes, apply some operations, and writes outputs.
+	// The input and output contain arbitrary bytes (maybe HCL or not).
 	// Note that a filename is used only for an error message.
-	Apply(r io.Reader, w io.Writer, filename string) error
+	Apply(input []byte, filename string) ([]byte, error)
 }
 
 // Source is an interface which reads string and writes HCL

--- a/editor/operator.go
+++ b/editor/operator.go
@@ -35,3 +35,11 @@ type Sink interface {
 	// Sink reads HCL and writes bytes.
 	Sink(*hclwrite.File) ([]byte, error)
 }
+
+// Formatter is an interface which reads HCL, formats tokens and writes bytes.
+// Formatter has a signature similar to Sink, but they have different features,
+// so we distinguish them with types.
+type Formatter interface {
+	// Format reads HCL, formats tokens and writes bytes.
+	Format(*hclwrite.File) ([]byte, error)
+}

--- a/editor/operator_derive_test.go
+++ b/editor/operator_derive_test.go
@@ -1,0 +1,117 @@
+package editor
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestOperatorDeriveApply(t *testing.T) {
+	cases := []struct {
+		name    string
+		src     string
+		address string
+		ok      bool
+		want    string
+	}{
+		{
+			name: "match",
+			src: `
+a0 = v0
+a1 = v1
+`,
+			address: "a0",
+			ok:      true,
+			want:    "v0\n",
+		},
+		{
+			name: "not found",
+			src: `
+a0 = v0
+a1 = v1
+`,
+			address: "a2",
+			ok:      true,
+			want:    "",
+		},
+		{
+			name: "syntax error",
+			src: `
+b1 {
+  a1 = v1
+`,
+			ok:   false,
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			o := NewDeriveOperator(NewAttributeGetSink(tc.address))
+			output, err := o.Apply([]byte(tc.src), "test")
+			if tc.ok && err != nil {
+				t.Fatalf("unexpected err = %s", err)
+			}
+
+			got := string(output)
+			if !tc.ok && err == nil {
+				t.Fatalf("expected to return an error, but no error, outStream: \n%s", got)
+			}
+
+			if got != tc.want {
+				t.Fatalf("got:\n%s\nwant:\n%s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDeriveStream(t *testing.T) {
+	cases := []struct {
+		name    string
+		src     string
+		address string
+		ok      bool
+		want    string
+	}{
+		{
+			name: "match",
+			src: `
+a0 = v0
+a1 = v1
+`,
+			address: "a0",
+			ok:      true,
+			want:    "v0\n",
+		},
+		{
+			name: "not found",
+			src: `
+a0 = v0
+a1 = v1
+`,
+			address: "a2",
+			ok:      true,
+			want:    "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inStream := bytes.NewBufferString(tc.src)
+			outStream := new(bytes.Buffer)
+			sink := NewAttributeGetSink(tc.address)
+			err := DeriveStream(inStream, outStream, "test", sink)
+			if tc.ok && err != nil {
+				t.Fatalf("unexpected err = %s", err)
+			}
+
+			got := outStream.String()
+			if !tc.ok && err == nil {
+				t.Fatalf("expected to return an error, but no error, outStream: \n%s", got)
+			}
+
+			if got != tc.want {
+				t.Fatalf("got:\n%s\nwant:\n%s", got, tc.want)
+			}
+		})
+	}
+}

--- a/editor/operator_edit.go
+++ b/editor/operator_edit.go
@@ -26,33 +26,42 @@ func NewEditOperator(filter Filter) Operator {
 	}
 }
 
-// Apply reads an input stream, applies some filters and formatter, and writes an output stream.
-// The input and output streams contain arbitrary bytes in HCL.
+// Apply reads input bytes, applies some filters and formatter, and writes output.
+// The input and output contain arbitrary bytes in HCL.
 // Note that a filename is used only for an error message.
-func (o *EditOperator) Apply(r io.Reader, w io.Writer, filename string) error {
+func (o *EditOperator) Apply(input []byte, filename string) ([]byte, error) {
+	inFile, err := o.source.Source(input, filename)
+	if err != nil {
+		return nil, err
+	}
+
+	tmpFile, err := o.filter.Filter(inFile)
+	if err != nil {
+		return nil, err
+	}
+
+	output := tmpFile.BuildTokens(nil).Bytes()
+	// Skip the formatter if the filter didn't change contents to suppress meaningless diff
+	if bytes.Equal(input, output) {
+		return output, nil
+	}
+
+	return o.formatter.Format(tmpFile)
+}
+
+// EditStream is a helper method which builds an EditorOperator from a given
+// filter and apply it to stream.
+// Note that a filename is used only for an error message.
+func EditStream(r io.Reader, w io.Writer, filename string, filter Filter) error {
 	input, err := ioutil.ReadAll(r)
 	if err != nil {
 		return fmt.Errorf("failed to read input: %s", err)
 	}
 
-	inFile, err := o.source.Source(input, filename)
+	o := NewEditOperator(filter)
+	output, err := o.Apply(input, filename)
 	if err != nil {
 		return err
-	}
-
-	tmpFile, err := o.filter.Filter(inFile)
-	if err != nil {
-		return err
-	}
-
-	output := tmpFile.BuildTokens(nil).Bytes()
-	isUpdated := !bytes.Equal(input, output)
-	// Skip the formatter if the filter didn't change contents to suppress meaningless diff
-	if isUpdated {
-		output, err = o.formatter.Format(tmpFile)
-		if err != nil {
-			return err
-		}
 	}
 
 	if _, err := w.Write(output); err != nil {

--- a/editor/operator_edit_test.go
+++ b/editor/operator_edit_test.go
@@ -1,0 +1,163 @@
+package editor
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestOperatorEditApply(t *testing.T) {
+	cases := []struct {
+		name    string
+		src     string
+		address string
+		value   string
+		ok      bool
+		want    string
+	}{
+		{
+			name: "match (formatted)",
+			src: `
+a0 = v0
+a1 = v1
+`,
+			address: "a0",
+			value:   "v2",
+			ok:      true,
+			want: `
+a0 = v2
+a1 = v1
+`,
+		},
+		{
+			name: "match (unformatted)",
+			src: `
+a0 = v0
+a1= v1
+`,
+			address: "a0",
+			value:   "v2",
+			ok:      true,
+			want: `
+a0 = v2
+a1 = v1
+`,
+		},
+		{
+			name: "not found (formatted)",
+			src: `
+a0 = v0
+a1 = v1
+`,
+			address: "a3",
+			value:   "v3",
+			ok:      true,
+			want: `
+a0 = v0
+a1 = v1
+`,
+		},
+		{
+			name: "not found (unformatted)", // skip format
+			src: `
+a0 = v0
+a1= v1
+`,
+			address: "a3",
+			value:   "v3",
+			ok:      true,
+			want: `
+a0 = v0
+a1= v1
+`,
+		},
+		{
+			name: "syntax error",
+			src: `
+b1 {
+  a1 = v1
+`,
+			ok:   false,
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			o := NewEditOperator(NewAttributeSetFilter(tc.address, tc.value))
+			output, err := o.Apply([]byte(tc.src), "test")
+			if tc.ok && err != nil {
+				t.Fatalf("unexpected err = %s", err)
+			}
+
+			got := string(output)
+			if !tc.ok && err == nil {
+				t.Fatalf("expected to return an error, but no error, outStream: \n%s", got)
+			}
+
+			if got != tc.want {
+				t.Fatalf("got:\n%s\nwant:\n%s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEditStream(t *testing.T) {
+	cases := []struct {
+		name    string
+		src     string
+		address string
+		value   string
+		ok      bool
+		want    string
+	}{
+		{
+			name: "match",
+			src: `
+a0 = v0
+a1 = v1
+`,
+			address: "a0",
+			value:   "v2",
+			ok:      true,
+			want: `
+a0 = v2
+a1 = v1
+`,
+		},
+		{
+			name: "not found",
+			src: `
+a0 = v0
+a1 = v1
+`,
+			address: "a3",
+			value:   "v3",
+			ok:      true,
+			want: `
+a0 = v0
+a1 = v1
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inStream := bytes.NewBufferString(tc.src)
+			outStream := new(bytes.Buffer)
+			filter := NewAttributeSetFilter(tc.address, tc.value)
+			err := EditStream(inStream, outStream, "test", filter)
+			if tc.ok && err != nil {
+				t.Fatalf("unexpected err = %s", err)
+			}
+
+			got := outStream.String()
+			if !tc.ok && err == nil {
+				t.Fatalf("expected to return an error, but no error, outStream: \n%s", got)
+			}
+
+			if got != tc.want {
+				t.Fatalf("got:\n%s\nwant:\n%s", got, tc.want)
+			}
+		})
+	}
+}

--- a/editor/sink_attribute_get_test.go
+++ b/editor/sink_attribute_get_test.go
@@ -1,7 +1,6 @@
 package editor
 
 import (
-	"bytes"
 	"testing"
 )
 
@@ -199,15 +198,13 @@ b1 "l1" "l2" {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			inStream := bytes.NewBufferString(tc.src)
-			outStream := new(bytes.Buffer)
 			o := NewDeriveOperator(NewAttributeGetSink(tc.address))
-			err := o.Apply(inStream, outStream, "test")
+			output, err := o.Apply([]byte(tc.src), "test")
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err = %s", err)
 			}
 
-			got := outStream.String()
+			got := string(output)
 			if !tc.ok && err == nil {
 				t.Fatalf("expected to return an error, but no error, outStream: \n%s", got)
 			}

--- a/editor/sink_block_list_test.go
+++ b/editor/sink_block_list_test.go
@@ -1,7 +1,6 @@
 package editor
 
 import (
-	"bytes"
 	"testing"
 )
 
@@ -38,15 +37,13 @@ b2.l1
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			inStream := bytes.NewBufferString(tc.src)
-			outStream := new(bytes.Buffer)
 			o := NewDeriveOperator(NewBlockListSink())
-			err := o.Apply(inStream, outStream, "test")
+			output, err := o.Apply([]byte(tc.src), "test")
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err = %s", err)
 			}
 
-			got := outStream.String()
+			got := string(output)
 			if !tc.ok && err == nil {
 				t.Fatalf("expected to return an error, but no error, outStream: \n%s", got)
 			}

--- a/editor/sink_formatter.go
+++ b/editor/sink_formatter.go
@@ -17,7 +17,6 @@ func NewFormatterSink() Sink {
 
 // Sink reads HCL and writes formatted contents.
 func (s *FormatterSink) Sink(inFile *hclwrite.File) ([]byte, error) {
-	raw := inFile.BuildTokens(nil).Bytes()
-	out := hclwrite.Format(raw)
-	return out, nil
+	f := NewDefaultFormatter()
+	return f.Format(inFile)
 }

--- a/editor/sink_formatter_test.go
+++ b/editor/sink_formatter_test.go
@@ -1,7 +1,6 @@
 package editor
 
 import (
-	"bytes"
 	"testing"
 )
 
@@ -57,15 +56,13 @@ b1 {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			inStream := bytes.NewBufferString(tc.src)
-			outStream := new(bytes.Buffer)
 			o := NewDeriveOperator(NewFormatterSink())
-			err := o.Apply(inStream, outStream, "test")
+			output, err := o.Apply([]byte(tc.src), "test")
 			if tc.ok && err != nil {
 				t.Fatalf("unexpected err = %s", err)
 			}
 
-			got := outStream.String()
+			got := string(output)
 			if !tc.ok && err == nil {
 				t.Fatalf("expected to return an error, but no error, outStream: \n%s", got)
 			}


### PR DESCRIPTION
This is a stepping stone towards to the in-place update. #4

Historically, I wrote the [tfupdate](https://github.com/minamijoyo/tfupdate) before the hcledit. The tfupdate is specialized for updating Terraform dependencies. In the tfupdate, it's natural to update files and directories in-place. Adding the in-place update feature to the hcledit will probably duplicate many logics, so I'm thinking of replacing the hcl related implementation of the tfupdate using the hcledit.

With that in mind,  I made some changes not to break the current tfupdate behavior. However this will slightly break the hcledit (but I think it's not so harmful).

(1) Skip formatter if filter didn't change contents to suppress meaningless diff
(2) Change input and output type for Operator.Apply() to []byte

The first is a breaking change for the hcledit CLI users. The second only affects the editor package interface. They were required for not to update the timestamp of file if its contents has no change.