### PR TITLE
Add Apple Silicon (ARM 64) build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,7 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
     ldflags:
       - -s -w
       - -X github.com/minamijoyo/hcledit/cmd.Version={{.Version}}


### PR DESCRIPTION
Add support for Apple Silicon macs by adding an `arm64` build to `.goreleaser.yml`.