### PR TITLE
Use a native cache feature in actions/setup-go

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,6 +19,7 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version-file: '.go-version'
+        cache: true
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version-file: '.go-version'
+        cache: true
     - name: Generate github app token
       id: generate_github_app_token
       uses: tibdex/github-app-token@f717b5ecd4534d3c4df4ce9b5c1c2214f0f7cd06  # v1.6.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,11 +22,6 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version-file: '.go-version'
-    - uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+        cache: true
     - name: test
       run: make test


### PR DESCRIPTION
The actions/setup-go has a native cache feature.
There is no need to use actions/cache.