### PR TITLE
Fix unexpected format when files do not end with newline

### DIFF
--- a/editor/filter_vertical_formatter.go
+++ b/editor/filter_vertical_formatter.go
@@ -62,6 +62,9 @@ func trimTrailingDuplicatedNewLine(tokens hclwrite.Tokens) hclwrite.Tokens {
 		if tokens[end-1].Type == hclsyntax.TokenEOF {
 			// skip EOF
 			eof = tokens[end-1]
+			if tokens[end-2].Type != hclsyntax.TokenNewline {
+				break
+			}
 			continue
 		}
 		if tokens[end-1].Type == hclsyntax.TokenNewline &&

--- a/editor/filter_vertical_formatter_test.go
+++ b/editor/filter_vertical_formatter_test.go
@@ -44,6 +44,12 @@ b1 {
 b2 l1 {}
 `,
 		},
+		{
+			name: "non-POSIX style end of file",
+			src:  `a0 = v0`,
+			ok:   true,
+			want: `a0 = v0`,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
If a file does not end with a newline, unexpected formatting is applied, like this:

```
$ printf "a0 = v0" | hcledit block rm foo     
a0
```

Unfortunately, I sometimes encounter files that don't end with a newline.  So I would like to fix this.