### PR TITLE
Fix attribute get --with-comments for inline comments

### DIFF
--- a/cmd/attribute_test.go
+++ b/cmd/attribute_test.go
@@ -71,13 +71,13 @@ locals {
   }
 `,
 		},
-		// does not pass at current
-		// {
-		// 	name: "single with comments",
-		// 	args: []string{"--with-comments", "locals.attribute"},
-		// 	ok:   true,
-		// 	want: `"foo" #comment`,
-		// },
+		{
+			name: "single with comments",
+			args: []string{"--with-comments", "locals.attribute"},
+			ok:   true,
+			want: `"foo" # comment
+`,
+		},
 		{
 			name: "single without comments",
 			args: []string{"locals.attribute"},

--- a/editor/sink_attribute_get_test.go
+++ b/editor/sink_attribute_get_test.go
@@ -48,7 +48,7 @@ a1 = v1
 			want:         "",
 		},
 		{
-			name: "attribute with comments",
+			name: "attribute without comments",
 			src: `
 // attr comment
 a0 = v0 // inline comment
@@ -60,7 +60,19 @@ a1 = v1
 			want:         "v0\n",
 		},
 		{
-			name: "multiline attribute with comments",
+			name: "attribute with comments",
+			src: `
+// attr comment
+a0 = v0 // inline comment
+a1 = v1
+`,
+			address:      "a0",
+			withComments: true,
+			ok:           true,
+			want:         "v0 // inline comment\n",
+		},
+		{
+			name: "multiline attribute without comments",
 			src: `
 // attr comment
 a0 = v0
@@ -83,6 +95,34 @@ a2 = v2
   "val3",
   "val4",
 
+  "val5",
+]
+`,
+		},
+		{
+			name: "multiline attribute with comments",
+			src: `
+// attr comment
+a0 = v0
+a1 = [
+  "val1",
+  "val2", // inline comment
+  "val3", # another comment
+  "val4",
+  # a ocmment line
+  "val5",
+]
+a2 = v2
+`,
+			address:      "a1",
+			withComments: true,
+			ok:           true,
+			want: `[
+  "val1",
+  "val2", // inline comment
+  "val3", # another comment
+  "val4",
+  # a ocmment line
   "val5",
 ]
 `,


### PR DESCRIPTION
Follow-up to #103.

Inline comments belong to attributes, not expressions. When the `--with-comments` flag is specified, we need to return tokens on the right side of the equals sign.

```
$ cat tmp/iss102/main.tf
locals {
  map = {
    # comment
    attribute = "bar"
  }
  attribute = "foo" # comment
}

$ go run main.go attribute get -f tmp/iss102/main.tf locals.attribute
"foo"

$ go run main.go attribute get -f tmp/iss102/main.tf locals.attribute --with-comments
"foo" # comment

$ go run main.go attribute get -f tmp/iss102/main.tf locals.map
{

    attribute = "bar"
  }

[hcledit@fix-inline-comments|✔]$ go run main.go attribute get -f tmp/iss102/main.tf locals.map --with-comments
{
    # comment
    attribute = "bar"
  }
```