### PR TITLE
new cmd: block new <blockType> <labels>...

### DIFF
--- a/cmd/block.go
+++ b/cmd/block.go
@@ -28,6 +28,7 @@ func newBlockCmd() *cobra.Command {
 		newBlockListCmd(),
 		newBlockRmCmd(),
 		newBlockAppendCmd(),
+		newBlockNewCmd(),
 	)
 
 	return cmd
@@ -200,8 +201,8 @@ Arguments:
 }
 
 func runBlockNewCmd(cmd *cobra.Command, args []string) error {
-	if len(args) < 2 {
-		return fmt.Errorf("expected at least 2 arguments, but got %d arguments", len(args))
+	if len(args) < 1 {
+		return fmt.Errorf("expected at least 1 argument, but got %d arguments", len(args))
 	}
 
 	blockType := args[0]

--- a/cmd/block.go
+++ b/cmd/block.go
@@ -187,13 +187,13 @@ func runBlockAppendCmd(cmd *cobra.Command, args []string) error {
 
 func newBlockNewCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "new <BLOCK_TYPE> <LABEL>...",
+		Use:   "new <BLOCK_TYPE> [LABEL...]",
 		Short: "Create a new block",
 		Long: `Create a new block
 
 Arguments:
   BLOCK_TYPE       A block type to be created.
-  LABEL            A label of block to be created.
+  LABEL           Optional labels for the block. Multiple labels can be provided.
 `,
 		RunE: runBlockNewCmd,
 	}

--- a/cmd/block.go
+++ b/cmd/block.go
@@ -183,3 +183,33 @@ func runBlockAppendCmd(cmd *cobra.Command, args []string) error {
 	c := newDefaultClient(cmd)
 	return c.Edit(file, update, filter)
 }
+
+func newBlockNewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "new <BLOCK_TYPE> <LABEL>...",
+		Short: "Create a new block",
+		Long: `Create a new block
+
+Arguments:
+  BLOCK_TYPE       A block type to be created.
+  LABEL            A label of block to be created.
+`,
+		RunE: runBlockNewCmd,
+	}
+	return cmd
+}
+
+func runBlockNewCmd(cmd *cobra.Command, args []string) error {
+	if len(args) < 2 {
+		return fmt.Errorf("expected at least 2 arguments, but got %d arguments", len(args))
+	}
+
+	blockType := args[0]
+	labels := args[1:]
+	file := viper.GetString("file")
+	update := viper.GetBool("update")
+
+	filter := editor.NewBlockNewFilter(blockType, labels)
+	c := newDefaultClient(cmd)
+	return c.Edit(file, update, filter)
+}

--- a/cmd/block_test.go
+++ b/cmd/block_test.go
@@ -315,3 +315,41 @@ func TestBlockAppend(t *testing.T) {
 		})
 	}
 }
+
+func TestBlockNew(t *testing.T) {
+
+	src := `variable "var1" {
+  type        = string
+  default     = "foo"
+  description = "example variable"
+}
+`
+
+	cases := []struct {
+		name string
+		args []string
+		ok   bool
+		want string
+	}{
+		{
+			name: "simple",
+			args: []string{"resource", "aws_instance", "example"},
+			ok:   true,
+			want: `variable "var1" {
+  type        = string
+  default     = "foo"
+  description = "example variable"
+}
+resource "aws_instance" "example" {
+}
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newMockCmd(newBlockNewCmd(), src)
+			assertMockCmd(t, cmd, tc.args, tc.ok, tc.want)
+		})
+	}
+}

--- a/cmd/block_test.go
+++ b/cmd/block_test.go
@@ -344,6 +344,25 @@ resource "aws_instance" "example" {
 }
 `,
 		},
+		{
+			name: "no args",
+			args: []string{},
+			ok:   false,
+			want: "",
+		},
+		{
+			name: "1 arg",
+			args: []string{"locals"},
+			ok:   true,
+			want: `variable "var1" {
+  type        = string
+  default     = "foo"
+  description = "example variable"
+}
+locals {
+}
+`,
+		},
 	}
 
 	for _, tc := range cases {

--- a/editor/filter_block_new.go
+++ b/editor/filter_block_new.go
@@ -1,0 +1,24 @@
+package editor
+
+import "github.com/hashicorp/hcl/v2/hclwrite"
+
+// BlockNewFilter is a filter implementation for creating a new block
+type BlockNewFilter struct {
+	blockType string
+	labels    []string
+}
+
+// Filter reads HCL and creates a new block with the given type and labels.
+func (b *BlockNewFilter) Filter(inFile *hclwrite.File) (*hclwrite.File, error) {
+	inFile.Body().AppendNewBlock(b.blockType, b.labels)
+	return inFile, nil
+}
+
+var _ Filter = (*BlockNewFilter)(nil)
+
+func NewBlockNewFilter(blockType string, labels []string) Filter {
+	return &BlockNewFilter{
+		blockType: blockType,
+		labels:    labels,
+	}
+}

--- a/editor/filter_block_new_test.go
+++ b/editor/filter_block_new_test.go
@@ -1,0 +1,94 @@
+package editor
+
+import (
+	"testing"
+)
+
+func TestBlockNewFilter(t *testing.T) {
+	cases := []struct {
+		name      string
+		src       string
+		blockType string
+		labels    []string
+		want      string
+	}{
+		{
+			name: "block with blockType and 2 labels, resource",
+			src: `
+variable "var1" {
+  type        = string
+  default     = "foo"
+  description = "example variable"
+}
+`,
+			blockType: "resource",
+			labels:    []string{"aws_instance", "example"},
+			want: `
+variable "var1" {
+  type        = string
+  default     = "foo"
+  description = "example variable"
+}
+resource "aws_instance" "example" {
+}
+`,
+		},
+		{
+			name: "block with blockType and 1 label, module",
+			src: `
+variable "var1" {
+  type        = string
+  default     = "foo"
+  description = "example variable"
+}
+`,
+			blockType: "module",
+			labels:    []string{"example"},
+			want: `
+variable "var1" {
+  type        = string
+  default     = "foo"
+  description = "example variable"
+}
+module "example" {
+}
+`,
+		},
+		{
+			name: "block with blockType and 0 labels, locals",
+			src: `
+variable "var1" {
+  type        = string
+  default     = "foo"
+  description = "example variable"
+}
+`,
+			blockType: "locals",
+			labels:    []string{},
+			want: `
+variable "var1" {
+  type        = string
+  default     = "foo"
+  description = "example variable"
+}
+locals {
+}
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			o := NewEditOperator(NewBlockNewFilter(tc.blockType, tc.labels))
+			output, err := o.Apply([]byte(tc.src), "test")
+			if err != nil {
+				t.Fatalf("unexpected err = %s", err)
+			}
+
+			got := string(output)
+			if got != tc.want {
+				t.Fatalf("got:\n%s\nwant:\n%s", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
i was looking for a way to add root blocks to an hcl file.
found this comment in an issue https://github.com/minamijoyo/hcledit/issues/88#issuecomment-1741709806

the tests i have added are very terraform specific and the `hcledit block new <blockType> <labels>` may not be the best way to nest this cmd.

let me know in case there's any suggestions to make this better.
