### PR TITLE
Change the argument of the block new command to accept an address

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ resource "foo" "baz" {
 ```
 
 ```
-$ cat tmp/block.hcl | hcledit block new resource foo qux
+$ cat tmp/block.hcl | hcledit block new resource.foo.qux --newline
 resource "foo" "bar" {
   attr1 = "val1"
 }
@@ -237,6 +237,7 @@ resource "foo" "bar" {
 resource "foo" "baz" {
   attr1 = "val2"
 }
+
 resource "foo" "qux" {
 }
 ```

--- a/cmd/block.go
+++ b/cmd/block.go
@@ -187,36 +187,34 @@ func runBlockAppendCmd(cmd *cobra.Command, args []string) error {
 
 func newBlockNewCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "new <BLOCK_TYPE> [LABEL...]",
+		Use:   "new <ADDRESS>",
 		Short: "Create a new block",
 		Long: `Create a new block
 
 Arguments:
-  BLOCK_TYPE       A block type to be created.
-  LABEL           Optional labels for the block. Multiple labels can be provided.
+  ADDRESS          An address of block to be created.
 `,
 		RunE: runBlockNewCmd,
 	}
 
 	flags := cmd.Flags()
-	flags.Bool("newline", false, "Append a new line before a new child block")
+	flags.Bool("newline", false, "Append a new line before a new block")
 	_ = viper.BindPFlag("block.new.newline", flags.Lookup("newline"))
 
 	return cmd
 }
 
 func runBlockNewCmd(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("expected at least 1 argument, but got %d arguments", len(args))
+	if len(args) != 1 {
+		return fmt.Errorf("expected 1 argument, but got %d arguments", len(args))
 	}
 
-	blockType := args[0]
-	labels := args[1:]
+	address := args[0]
 	file := viper.GetString("file")
 	update := viper.GetBool("update")
 	newline := viper.GetBool("block.new.newline")
 
-	filter := editor.NewBlockNewFilter(blockType, labels, newline)
+	filter := editor.NewBlockNewFilter(address, newline)
 	c := newDefaultClient(cmd)
 	return c.Edit(file, update, filter)
 }

--- a/cmd/block_test.go
+++ b/cmd/block_test.go
@@ -332,8 +332,8 @@ func TestBlockNew(t *testing.T) {
 		want string
 	}{
 		{
-			name: "simple",
-			args: []string{"resource", "aws_instance", "example"},
+			name: "with labels",
+			args: []string{"resource.aws_instance.example"},
 			ok:   true,
 			want: `variable "var1" {
   type        = string
@@ -345,13 +345,7 @@ resource "aws_instance" "example" {
 `,
 		},
 		{
-			name: "no args",
-			args: []string{},
-			ok:   false,
-			want: "",
-		},
-		{
-			name: "1 arg",
+			name: "no labels",
 			args: []string{"locals"},
 			ok:   true,
 			want: `variable "var1" {
@@ -362,6 +356,32 @@ resource "aws_instance" "example" {
 locals {
 }
 `,
+		},
+		{
+			name: "newline",
+			args: []string{"resource.aws_instance.example", "--newline"},
+			ok:   true,
+			want: `variable "var1" {
+  type        = string
+  default     = "foo"
+  description = "example variable"
+}
+
+resource "aws_instance" "example" {
+}
+`,
+		},
+		{
+			name: "no args",
+			args: []string{},
+			ok:   false,
+			want: "",
+		},
+		{
+			name: "too many args",
+			args: []string{"foo", "bar"},
+			ok:   false,
+			want: "",
 		},
 	}
 

--- a/editor/filter_block_new.go
+++ b/editor/filter_block_new.go
@@ -1,29 +1,36 @@
 package editor
 
-import "github.com/hashicorp/hcl/v2/hclwrite"
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
 
 // BlockNewFilter is a filter implementation for creating a new block
 type BlockNewFilter struct {
-	blockType string
-	labels    []string
-	newline   bool
+	address string
+	newline bool
 }
 
 // Filter reads HCL and creates a new block with the given type and labels.
-func (b *BlockNewFilter) Filter(inFile *hclwrite.File) (*hclwrite.File, error) {
-	if b.newline {
+func (f *BlockNewFilter) Filter(inFile *hclwrite.File) (*hclwrite.File, error) {
+	typeName, labels, err := parseAddress(f.address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse address: %s", err)
+	}
+
+	if f.newline {
 		inFile.Body().AppendNewline()
 	}
-	inFile.Body().AppendNewBlock(b.blockType, b.labels)
+	inFile.Body().AppendNewBlock(typeName, labels)
 	return inFile, nil
 }
 
 var _ Filter = (*BlockNewFilter)(nil)
 
-func NewBlockNewFilter(blockType string, labels []string, newline bool) Filter {
+func NewBlockNewFilter(address string, newline bool) Filter {
 	return &BlockNewFilter{
-		blockType: blockType,
-		labels:    labels,
-		newline:   newline,
+		address: address,
+		newline: newline,
 	}
 }

--- a/editor/filter_block_new_test.go
+++ b/editor/filter_block_new_test.go
@@ -6,12 +6,11 @@ import (
 
 func TestBlockNewFilter(t *testing.T) {
 	cases := []struct {
-		name      string
-		src       string
-		blockType string
-		labels    []string
-		newline   bool
-		want      string
+		name    string
+		src     string
+		address string
+		newline bool
+		want    string
 	}{
 		{
 			name: "block with blockType and 2 labels, resource with newline",
@@ -22,9 +21,8 @@ variable "var1" {
   description = "example variable"
 }
 `,
-			blockType: "resource",
-			labels:    []string{"aws_instance", "example"},
-			newline:   true,
+			address: "resource.aws_instance.example",
+			newline: true,
 			want: `
 variable "var1" {
   type        = string
@@ -45,9 +43,8 @@ variable "var1" {
   description = "example variable"
 }
 `,
-			blockType: "module",
-			labels:    []string{"example"},
-			newline:   false,
+			address: "module.example",
+			newline: false,
 			want: `
 variable "var1" {
   type        = string
@@ -67,9 +64,8 @@ variable "var1" {
   description = "example variable"
 }
 `,
-			blockType: "locals",
-			labels:    []string{},
-			newline:   false,
+			address: "locals",
+			newline: false,
 			want: `
 variable "var1" {
   type        = string
@@ -84,7 +80,7 @@ locals {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			o := NewEditOperator(NewBlockNewFilter(tc.blockType, tc.labels, tc.newline))
+			o := NewEditOperator(NewBlockNewFilter(tc.address, tc.newline))
 			output, err := o.Apply([]byte(tc.src), "test")
 			if err != nil {
 				t.Fatalf("unexpected err = %s", err)


### PR DESCRIPTION
The current interface of the block new command is inconsistent when compared to the block append command in terms of passing labels for blocks to be added, space-delimited, and dot-delimited. The dot-delimited address notation is ambiguous concerning nested blocks. Still, even if someone wanted to create nested blocks, space delimitation would not solve the problem, and neither is sufficiently expressive. Therefore, I have decided that it is more consistent and reasonable to accept the limitation that nested blocks cannot be created in a single shot, align the notation with block append, and change how the block new command takes arguments.