### PR TITLE
feat: add 'block merge' command for AST-aware block synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,50 @@ resource "foo" "qux" {
 }
 ```
 
+### block merge
+
+Merge synchronizes module blocks between a source HCL file and a target HCL file.
+It will intelligently update existing blocks with new attribute values from the source,
+and append entirely new blocks if they are missing from the target.
+
+This command is useful for GitOps workflows promoting environments (e.g., merging `dev` into `prod`)
+where you want to sync version bumps but protect target-specific variables.
+
+```bash
+$ cat dev.hcl
+module "network" {
+  version = "v2.0.0"
+  env     = "dev"
+}
+
+module "database" {
+  version = "v1.5.0"
+  env     = "dev"
+}
+
+$ cat prod.hcl
+module "network" {
+  version = "v1.0.0"
+  env     = "prod"
+}
+
+```
+
+The `--ignore-attr` flag prevents upstream variables (e.g., `env = "dev"`)
+from accidentally overwriting your target environment's variables (e.g., `env = "prod"`)
+during an automated merge.
+It acts as a safety filter, allowing you to sync structural updates,
+like new modules or version bumps,
+while strictly protecting environment-specific configurations.
+
+``` bash
+$ hcledit block merge \
+    --source dev.tf \
+    --target prod.tf \
+    --ignore-attr env \
+    --set-attr env=prod
+```
+
 ### body
 
 ```

--- a/README.md
+++ b/README.md
@@ -273,8 +273,7 @@ and append entirely new blocks if they are missing from the target.
 This command is useful for GitOps workflows promoting environments (e.g., merging `dev` into `prod`)
 where you want to sync version bumps but protect target-specific variables.
 
-```bash
-$ cat dev.hcl
+```dev.hcl
 module "network" {
   version = "v2.0.0"
   env     = "dev"
@@ -284,13 +283,13 @@ module "database" {
   version = "v1.5.0"
   env     = "dev"
 }
+```
 
-$ cat prod.hcl
+```prod.hcl
 module "network" {
   version = "v1.0.0"
   env     = "prod"
 }
-
 ```
 
 The `--ignore-attr` flag prevents upstream variables (e.g., `env = "dev"`)
@@ -302,8 +301,8 @@ while strictly protecting environment-specific configurations.
 
 ``` bash
 $ hcledit block merge \
-    --source dev.tf \
-    --target prod.tf \
+    --source dev.hcl \
+    --target prod.hcl \
     --ignore-attr env \
     --set-attr env=prod
 ```

--- a/cmd/attribute.go
+++ b/cmd/attribute.go
@@ -63,7 +63,7 @@ func runAttributeGetCmd(cmd *cobra.Command, args []string) error {
 	update := viper.GetBool("update")
 	withComments := viper.GetBool("attribute.get.withComments")
 	if update {
-		return errors.New("The update flag is not allowed")
+		return errors.New("the update flag is not allowed")
 	}
 
 	sink := editor.NewAttributeGetSink(address, withComments)

--- a/cmd/block.go
+++ b/cmd/block.go
@@ -11,7 +11,6 @@ import (
 
 func init() {
 	RootCmd.AddCommand(newBlockCmd())
-	RootCmd.AddCommand(newBlockMergeCmd())
 }
 
 func newBlockCmd() *cobra.Command {
@@ -30,6 +29,7 @@ func newBlockCmd() *cobra.Command {
 		newBlockRmCmd(),
 		newBlockAppendCmd(),
 		newBlockNewCmd(),
+		newBlockMergeCmd(),
 	)
 
 	return cmd

--- a/cmd/block.go
+++ b/cmd/block.go
@@ -112,7 +112,7 @@ func runBlockListCmd(cmd *cobra.Command, args []string) error {
 	file := viper.GetString("file")
 	update := viper.GetBool("update")
 	if update {
-		return errors.New("The update flag is not allowed")
+		return errors.New("the update flag is not allowed")
 	}
 
 	sink := editor.NewBlockListSink()

--- a/cmd/block.go
+++ b/cmd/block.go
@@ -11,6 +11,7 @@ import (
 
 func init() {
 	RootCmd.AddCommand(newBlockCmd())
+	RootCmd.AddCommand(newBlockMergeCmd())
 }
 
 func newBlockCmd() *cobra.Command {

--- a/cmd/block_merge.go
+++ b/cmd/block_merge.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/minamijoyo/hcledit/editor/merge"
+	"github.com/spf13/cobra"
+)
+
+type blockMergeOption struct {
+	sourceFile  string
+	targetFile  string
+	ignoreAttrs []string
+	setAttrs    map[string]string
+}
+
+func newBlockMergeCmd() *cobra.Command {
+	opt := &blockMergeOption{}
+
+	cmd := &cobra.Command{
+		Use:   "merge",
+		Short: "Merge module blocks from a source file into a target file",
+		Long: `Intelligently syncs blocks (e.g., modules) between two HCL files.
+Updates existing blocks and safely injects new blocks while respecting environment-specific variables.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runBlockMerge(cmd, opt)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opt.sourceFile, "source", "s", "", "Source HCL file (required)")
+	cmd.Flags().StringVarP(&opt.targetFile, "target", "t", "", "Target HCL file (required)")
+	cmd.Flags().StringSliceVarP(&opt.ignoreAttrs, "ignore-attr", "i", []string{}, "Attributes to ignore during merge (e.g., env)")
+	cmd.Flags().StringToStringVarP(&opt.setAttrs, "set-attr", "a", map[string]string{}, "Attributes to force-set on new blocks (e.g., env=prod)")
+
+	_ = cmd.MarkFlagRequired("source")
+	_ = cmd.MarkFlagRequired("target")
+
+	return cmd
+}
+
+func runBlockMerge(cmd *cobra.Command, opt *blockMergeOption) error {
+	srcBytes, err := os.ReadFile(opt.sourceFile)
+	if err != nil {
+		return fmt.Errorf("failed to read source file: %w", err)
+	}
+	src, diags := hclwrite.ParseConfig(srcBytes, opt.sourceFile, hcl.InitialPos)
+	if diags.HasErrors() {
+		return fmt.Errorf("source HCL parsing errors: %s", diags.Error())
+	}
+
+	tgtBytes, err := os.ReadFile(opt.targetFile)
+	if err != nil {
+		return fmt.Errorf("failed to read target file: %w", err)
+	}
+	tgt, diags := hclwrite.ParseConfig(tgtBytes, opt.targetFile, hcl.InitialPos)
+	if diags.HasErrors() {
+		return fmt.Errorf("target HCL parsing errors: %s", diags.Error())
+	}
+
+	merge.Blocks(src, tgt, "module", opt.ignoreAttrs, opt.setAttrs)
+
+	formattedBytes := hclwrite.Format(tgt.Bytes())
+
+	// Mode 0644 is standard for text files: rw-r--r--
+	// nolint:gosec // 0644 is standard and expected for Terraform text files
+	if err := os.WriteFile(opt.targetFile, formattedBytes, 0644); err != nil {
+		return fmt.Errorf("failed to write target file: %w", err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Successfully merged '%s' into '%s'\n", opt.sourceFile, opt.targetFile)
+	return nil
+}

--- a/editor/filter_block_get.go
+++ b/editor/filter_block_get.go
@@ -111,7 +111,7 @@ func matchLabels(lhs []string, rhs []string) bool {
 	}
 
 	for i := range lhs {
-		if !(lhs[i] == rhs[i] || lhs[i] == "*" || rhs[i] == "*") {
+		if lhs[i] != rhs[i] && lhs[i] != "*" && rhs[i] != "*" {
 			return false
 		}
 	}

--- a/editor/merge/merge.go
+++ b/editor/merge/merge.go
@@ -1,0 +1,73 @@
+// Package merge provides functionality to synchronize HCL blocks between two distinct configurations.
+package merge
+
+import (
+	"slices"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// findBlock is a helper to locate a block by its type and exact labels.
+func findBlock(body *hclwrite.Body, blockType string, labels []string) *hclwrite.Block {
+	for _, b := range body.Blocks() {
+		if b.Type() == blockType && slices.Equal(b.Labels(), labels) {
+			return b
+		}
+	}
+	return nil
+}
+
+// contains checks if a string slice contains a specific value.
+func contains(slice []string, val string) bool {
+	for _, item := range slice {
+		if item == val {
+			return true
+		}
+	}
+	return false
+}
+
+// Blocks synchronizes blocks of a specific type from source to target.
+// It updates existing blocks and appends missing blocks.
+// ignoreAttrs dictates which attributes should not be copied from the source.
+// setAttrs dictates which attributes should be forcefully injected into newly added blocks.
+func Blocks(source *hclwrite.File, target *hclwrite.File, blockType string, ignoreAttrs []string, setAttrs map[string]string) {
+	sourceBody := source.Body()
+	targetBody := target.Body()
+
+	for _, srcBlock := range sourceBody.Blocks() {
+		if srcBlock.Type() != blockType {
+			continue
+		}
+
+		labels := srcBlock.Labels()
+		tgtBlock := findBlock(targetBody, blockType, labels)
+
+		if tgtBlock != nil {
+			// Update existing block
+			for attrName, attr := range srcBlock.Body().Attributes() {
+				if !contains(ignoreAttrs, attrName) {
+					tgtBlock.Body().SetAttributeRaw(attrName, attr.Expr().BuildTokens(nil))
+				}
+			}
+		} else {
+			// Add new block
+			newBlock := hclwrite.NewBlock(blockType, labels)
+
+			for attrName, attr := range srcBlock.Body().Attributes() {
+				if !contains(ignoreAttrs, attrName) {
+					newBlock.Body().SetAttributeRaw(attrName, attr.Expr().BuildTokens(nil))
+				}
+			}
+
+			// Inject target-specific defaults for the new block
+			for attrName, attrVal := range setAttrs {
+				newBlock.Body().SetAttributeValue(attrName, cty.StringVal(attrVal))
+			}
+
+			targetBody.AppendNewline()
+			targetBody.AppendBlock(newBlock)
+		}
+	}
+}

--- a/editor/merge/merge_test.go
+++ b/editor/merge/merge_test.go
@@ -8,15 +8,19 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
 
-func TestMergeBlocks(t *testing.T) {
+func TestBlocks(t *testing.T) {
 	tests := []struct {
 		name        string
 		sourceHCL   string
 		targetHCL   string
+		blockType   string
 		ignoreAttrs []string
 		setAttrs    map[string]string
 		expectedHCL string
 	}{
+		// ---------------------------------------------------------
+		// HAPPY PATHS
+		// ---------------------------------------------------------
 		{
 			name: "update existing block and preserve target env",
 			sourceHCL: `
@@ -29,12 +33,96 @@ module "network" {
   version = "v1.0.0"
   env     = "prod"
 }`,
+			blockType:   "module",
 			ignoreAttrs: []string{"env"},
-			setAttrs:    nil,
 			expectedHCL: `
 module "network" {
   version = "v2.0.0"
   env     = "prod"
+}`,
+		},
+		{
+			name: "add missing block and inject target env",
+			sourceHCL: `module "db" {
+  version = "v1.5.0"
+  env     = "dev"
+}`,
+			targetHCL: `module "network" {
+  version = "v1.0.0"
+}`,
+			blockType:   "module",
+			ignoreAttrs: []string{"env"},
+			setAttrs:    map[string]string{"env": "prod"},
+			expectedHCL: `module "network" {
+  version = "v1.0.0"
+}
+module "db" {
+  version = "v1.5.0"
+  env     = "prod"
+}`,
+		},
+		// ---------------------------------------------------------
+		// EDGE CASES
+		// ---------------------------------------------------------
+		{
+			name:      "edge case: empty source file leaves target unmodified",
+			sourceHCL: ``,
+			targetHCL: `
+module "network" {
+  version = "v1.0.0"
+}`,
+			blockType: "module",
+			expectedHCL: `
+module "network" {
+  version = "v1.0.0"
+}`,
+		},
+		{
+			name: "edge case: ignores unrelated block types in source",
+			sourceHCL: `
+resource "aws_s3_bucket" "b" {
+  bucket = "my-bucket"
+}
+
+module "network" {
+  version = "v2.0.0"
+}`,
+			targetHCL: `
+module "network" {
+  version = "v1.0.0"
+}`,
+			blockType: "module", // Only merge modules, ignore the s3 bucket
+			expectedHCL: `
+module "network" {
+  version = "v2.0.0"
+}`,
+		},
+		{
+			name: "edge case: handles blocks with multiple labels (resources)",
+			sourceHCL: `
+resource "aws_instance" "web" {
+  ami  = "ami-new"
+  type = "t3.large"
+}`,
+			targetHCL: `
+resource "aws_instance" "web" {
+  ami  = "ami-old"
+  type = "t2.micro"
+}
+
+resource "aws_instance" "db" {
+  ami = "ami-old"
+}`,
+			blockType:   "resource",
+			ignoreAttrs: []string{"type"}, // Protect the target's instance type
+			expectedHCL: `
+resource "aws_instance" "web" {
+  ami  = "ami-new"
+  type = "t2.micro"
+}
+
+resource "aws_instance" "db" {
+  ami = "ami-old"
 }`,
 		},
 	}
@@ -51,8 +139,10 @@ module "network" {
 				t.Fatalf("failed to parse target: %s", diags.Error())
 			}
 
-			Blocks(sourceFile, targetFile, "module", tt.ignoreAttrs, tt.setAttrs)
+			// Execute the engine using the dynamic blockType
+			Blocks(sourceFile, targetFile, tt.blockType, tt.ignoreAttrs, tt.setAttrs)
 
+			// Format bytes to normalize HCL whitespace before comparing
 			resultBytes := hclwrite.Format(targetFile.Bytes())
 
 			expectedFile, diags := hclwrite.ParseConfig([]byte(tt.expectedHCL), "expected.tf", hcl.InitialPos)
@@ -61,8 +151,8 @@ module "network" {
 			}
 			expectedBytes := hclwrite.Format(expectedFile.Bytes())
 
-			if !bytes.Equal(resultBytes, expectedBytes) {
-				t.Errorf("Merge output mismatch.\nGot:\n%s\nExpected:\n%s", string(resultBytes), string(expectedBytes))
+			if !bytes.Equal(bytes.TrimSpace(resultBytes), bytes.TrimSpace(expectedBytes)) {
+				t.Errorf("\n=== Output Mismatch ===\nGot:\n%s\nExpected:\n%s", string(resultBytes), string(expectedBytes))
 			}
 		})
 	}

--- a/editor/merge/merge_test.go
+++ b/editor/merge/merge_test.go
@@ -1,0 +1,69 @@
+package merge
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+func TestMergeBlocks(t *testing.T) {
+	tests := []struct {
+		name        string
+		sourceHCL   string
+		targetHCL   string
+		ignoreAttrs []string
+		setAttrs    map[string]string
+		expectedHCL string
+	}{
+		{
+			name: "update existing block and preserve target env",
+			sourceHCL: `
+module "network" {
+  version = "v2.0.0"
+  env     = "dev"
+}`,
+			targetHCL: `
+module "network" {
+  version = "v1.0.0"
+  env     = "prod"
+}`,
+			ignoreAttrs: []string{"env"},
+			setAttrs:    nil,
+			expectedHCL: `
+module "network" {
+  version = "v2.0.0"
+  env     = "prod"
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sourceFile, diags := hclwrite.ParseConfig([]byte(tt.sourceHCL), "source.tf", hcl.InitialPos)
+			if diags.HasErrors() {
+				t.Fatalf("failed to parse source: %s", diags.Error())
+			}
+
+			targetFile, diags := hclwrite.ParseConfig([]byte(tt.targetHCL), "target.tf", hcl.InitialPos)
+			if diags.HasErrors() {
+				t.Fatalf("failed to parse target: %s", diags.Error())
+			}
+
+			Blocks(sourceFile, targetFile, "module", tt.ignoreAttrs, tt.setAttrs)
+
+			resultBytes := hclwrite.Format(targetFile.Bytes())
+
+			expectedFile, diags := hclwrite.ParseConfig([]byte(tt.expectedHCL), "expected.tf", hcl.InitialPos)
+			if diags.HasErrors() {
+				t.Fatalf("failed to parse expected: %s", diags.Error())
+			}
+			expectedBytes := hclwrite.Format(expectedFile.Bytes())
+
+			if !bytes.Equal(resultBytes, expectedBytes) {
+				t.Errorf("Merge output mismatch.\nGot:\n%s\nExpected:\n%s", string(resultBytes), string(expectedBytes))
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/hashicorp/logutils"
 	"github.com/minamijoyo/hcledit/cmd"
@@ -12,7 +13,14 @@ import (
 
 func main() {
 	log.SetOutput(logOutput())
-	log.Printf("[INFO] CLI args: %#v", os.Args)
+	// Sanitize os.Args to prevent CRLF log injection
+	sanitizedArgs := make([]string, len(os.Args))
+	for i, arg := range os.Args {
+		clean := strings.ReplaceAll(arg, "\n", " ")
+		clean = strings.ReplaceAll(clean, "\r", "")
+		sanitizedArgs[i] = clean
+	}
+	log.Printf("[INFO] CLI args: %q", sanitizedArgs)
 	if err := cmd.RootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
Adds the `hcledit block merge` subcommand to synchronize structural HCL blocks between files while protecting target-specific attributes.

### Motivation

In GitOps workflows, promoting Terraform code between environments (e.g., dev to prod)
requires updating shared structure (like module version bumps or new resources) 
without overwriting environment-specific variables (like `env = "prod"`).
Standard file copying or text diffs overwrite these target variables.

### Functionality

This command performs an AST-aware upsert (updates existing blocks, appends missing blocks) and 
provides two flags to handle environment separation:

- `--ignore-attr`: Prevents specific source attributes from overwriting target values.
- `--set-attr`: Injects baseline attributes into newly added blocks.

### Additional Changes

Fixed pre-existing golangci-lint (v1.59.1) warnings (gosec, staticcheck, revive)
to ensure the CI pipeline remains completely green.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue) (Legacy linter fixes)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Testing

- Added table-driven tests in merge_test.go covering:
- Updating existing blocks while preserving ignored target attributes.
- Appending new blocks and injecting required target attributes.
- Handling missing or mismatched attributes.